### PR TITLE
KOIKI-FW API endpoint("")スラッシュなし統一対応

### DIFF
--- a/libkoiki/api/dependencies.py
+++ b/libkoiki/api/dependencies.py
@@ -155,8 +155,8 @@ def get_login_security_service() -> LoginSecurityService:
 LoginSecurityServiceDep = Annotated[LoginSecurityService, Depends(get_login_security_service)]
 
 # --- 認証・認可 ---
-# get_current_user_from_token はトークン検証とDBアクセスを行う
-CurrentUserDep = Annotated[UserModel, Depends(get_current_user_from_token)]
+# get_current_user_from_token はトークン検証とユーザーIDを返す（DBアクセスは別途実行）
+CurrentUserDep = Annotated[int, Depends(get_current_user_from_token)]
 
 # アクティブユーザーチェック
 async def get_current_active_user(

--- a/libkoiki/api/v1/endpoints/todos.py
+++ b/libkoiki/api/v1/endpoints/todos.py
@@ -22,7 +22,7 @@ router = APIRouter()
 
 # --- ToDo 作成 ---
 @router.post(
-    "/",
+    "",
     response_model=TodoResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create a new ToDo item for the current user",
@@ -51,7 +51,7 @@ async def create_todo(
 
 # --- ログインユーザーのToDo一覧取得 ---
 @router.get(
-    "/",
+    "",
     response_model=List[TodoResponse],
     summary="Get ToDo items for the current user",
     description="Retrieves a list of ToDo items belonging to the logged-in user.",

--- a/libkoiki/api/v1/endpoints/users.py
+++ b/libkoiki/api/v1/endpoints/users.py
@@ -23,7 +23,7 @@ router = APIRouter()
 
 # --- ユーザー作成 ---
 @router.post(
-    "/",
+    "",
     response_model=UserResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create a new user",
@@ -102,7 +102,7 @@ async def update_user_me(
 
 # --- ユーザー一覧取得 (管理者/特定権限持ち) ---
 @router.get(
-    "/",
+    "",
     response_model=List[UserResponse],
     summary="Get a list of users",
     description="Retrieves a list of users. Requires 'read:users' permission.",


### PR DESCRIPTION
フロントエンドアプリの実装検証中に、APIエンドポイントの終端表現の不統一が発覚した。
本来は、フロントエンド試し実装ブランチ作業のものであるが、KOIKI-FW関連のみ cherry-pick マージする