### PR TITLE
Topic/v0.7 followup cleanup

### DIFF
--- a/docs/agent/skills/README.md
+++ b/docs/agent/skills/README.md
@@ -25,3 +25,4 @@ Use these skills when the task already matches a known work type and you want co
 - Skill-specific metadata lives in each skill's `agents/openai.yaml`.
 - Claude Code discovery wrappers live under `.claude/skills/`.
 - `docs/agent/skills/` remains the canonical source for skill content.
+- Future maintainer/template role alignment is tracked in `future-role-alignment.md`.

--- a/docs/agent/skills/future-role-alignment.md
+++ b/docs/agent/skills/future-role-alignment.md
@@ -1,0 +1,79 @@
+# Agent Skill Future Role Alignment
+
+## Purpose
+
+This document records the v0.7 skill follow-up decisions without renaming or removing the current skills.
+
+The current skills remain the active discovery surface. Future maintainer/template roles are alignment targets for later extraction, not replacement names for current work.
+
+## Current Skill Mapping
+
+| Current skill | Current role | Future role alignment | Notes |
+| --- | --- | --- | --- |
+| `koiki-project-overview` | Repository routing and layer classification | Transitional overview / future maintainer overview seed | Keep as the first stop for ambiguous tasks until separate maintainer and template overviews exist. |
+| `koiki-libkoiki-feature-work` | Reusable framework implementation | Maintainer framework work | This is already the closest match to the future maintainer-facing framework skill. |
+| `koiki-app-feature-work` | Reference application backend implementation | Template backend work | This should remain focused on `components/koiki_ref_app` and avoid customer-specific app behavior. |
+| `koiki-auth-security` | Auth, SSO, SAML, RBAC, security logging | Cross-cutting security skill | Retain across maintainer and template phases because security behavior spans both layers. |
+| `koiki-testing` | Test scope and validation guidance | Cross-cutting testing skill | Retain across maintainer and template phases because validation choices span both layers. |
+
+## Phase A Status
+
+Phase A preserves the current skills and annotates their future intent.
+
+Completed decisions:
+
+- current skill names remain active
+- Claude wrappers remain thin adapters to canonical skills
+- no existing skill is deleted or renamed
+- current-to-future role mapping is documented above
+- individual `SKILL.md` files include a short future role note
+
+## Phase B Design
+
+Phase B is a future split design. It should not be implemented until the template boundaries have stayed stable in normal work.
+
+Maintainer-oriented skill candidates:
+
+- `koiki-maintainer-overview`
+  - route upstream maintenance work across framework, template backend, frontend starter, CI, Docker, and docs
+- `koiki-maintainer-framework-work`
+  - evolve reusable `components/libkoiki` framework behavior
+- `koiki-maintainer-template-backend-work`
+  - evolve upstream `components/koiki_ref_app` starter behavior
+- `koiki-maintainer-template-frontend-work`
+  - evolve upstream root `frontend/` starter behavior
+
+Template-oriented skill candidates:
+
+- `koiki-template-overview`
+  - guide copy-first template adoption and boundaries
+- `koiki-template-backend-feature-work`
+  - guide downstream backend work derived from `components/koiki_ref_app`
+- `koiki-template-frontend-feature-work`
+  - guide downstream frontend work derived from root `frontend/`
+
+Cross-cutting skills to retain:
+
+- auth/security guidance
+- testing guidance
+
+## Frontend Template Responsibility
+
+Root `frontend/` is the upstream starter frontend paired with `components/koiki_ref_app`.
+
+Future template frontend guidance should cover:
+
+- UI starter conventions and route structure
+- API client and auth integration expectations
+- BFF / browser-flow contracts when present
+- when a frontend change belongs in upstream `frontend/`
+- when project-specific frontend code should live under `apps/<project-slug>/frontend/`
+
+It should not treat root `frontend/` as part of the reusable Python framework package.
+
+## Migration Rules
+
+- Do not replace current skill names until replacement skills exist and wrappers are validated.
+- Do not split cross-cutting security or testing guidance prematurely.
+- Keep old-to-new role mapping visible while both naming schemes are in use.
+- Add consumer-oriented skills only after copy-first template adoption has concrete downstream examples.

--- a/docs/agent/skills/koiki-app-feature-work/SKILL.md
+++ b/docs/agent/skills/koiki-app-feature-work/SKILL.md
@@ -19,6 +19,10 @@ Typical targets:
 - `components/koiki_ref_app/src/koiki_ref_app/schemas/`
 - `components/koiki_ref_app/src/koiki_ref_app/core/`
 
+## Future Role Alignment
+
+This skill aligns with future template backend work. It should remain focused on the upstream reference application / backend starter, not downstream customer-specific app behavior.
+
 ## Workflow
 
 1. confirm the request is business-specific or application-specific
@@ -47,3 +51,4 @@ Typical targets:
 - `docs/agent/testing.md`
 - `docs/agent/auth-security.md`
 - `references/app-extension-patterns.md`
+- `docs/agent/skills/future-role-alignment.md`

--- a/docs/agent/skills/koiki-auth-security/SKILL.md
+++ b/docs/agent/skills/koiki-auth-security/SKILL.md
@@ -17,6 +17,10 @@ This skill applies to:
 - security logging and monitoring
 - SSO and SAML integration
 
+## Future Role Alignment
+
+This skill remains cross-cutting across future maintainer and template skill families. Auth and security work often spans `components/libkoiki`, `components/koiki_ref_app`, and frontend/browser flows, so it should not be split prematurely.
+
 ## Workflow
 
 1. identify whether the change is framework auth, app-specific SSO/SAML, or both
@@ -46,3 +50,4 @@ This skill applies to:
 - `docs/agent/libkoiki.md`
 - `docs/agent/app.md`
 - `references/auth-security-reference.md`
+- `docs/agent/skills/future-role-alignment.md`

--- a/docs/agent/skills/koiki-libkoiki-feature-work/SKILL.md
+++ b/docs/agent/skills/koiki-libkoiki-feature-work/SKILL.md
@@ -19,6 +19,10 @@ Target directories include:
 - `components/libkoiki/src/libkoiki/schemas/`
 - `components/libkoiki/src/libkoiki/db/`
 
+## Future Role Alignment
+
+This skill aligns with future maintainer framework work. It should continue to own reusable `components/libkoiki` behavior until a dedicated maintainer framework skill is introduced.
+
 ## Workflow
 
 1. confirm the feature is reusable and not business-specific
@@ -46,3 +50,4 @@ Target directories include:
 - `docs/agent/testing.md`
 - `docs/agent/auth-security.md`
 - `references/framework-patterns.md`
+- `docs/agent/skills/future-role-alignment.md`

--- a/docs/agent/skills/koiki-project-overview/SKILL.md
+++ b/docs/agent/skills/koiki-project-overview/SKILL.md
@@ -13,6 +13,10 @@ Use this skill first when the task is ambiguous or when the correct edit locatio
 - preserve the framework/application boundary
 - route the task to a more specific skill after the initial classification
 
+## Future Role Alignment
+
+This skill is the transitional repository overview and routing skill. In a later maintainer/template split, it is the seed for a maintainer overview skill and should remain active until replacement overview skills exist.
+
 ## Decision Rules
 
 - if the change is reusable across applications, prefer `components/libkoiki/`
@@ -28,3 +32,4 @@ Use this skill first when the task is ambiguous or when the correct edit locatio
 - `docs/agent/app.md`
 - `docs/agent/auth-security.md`
 - `docs/agent/testing.md`
+- `docs/agent/skills/future-role-alignment.md`

--- a/docs/agent/skills/koiki-testing/SKILL.md
+++ b/docs/agent/skills/koiki-testing/SKILL.md
@@ -13,6 +13,10 @@ Use this skill when implementing tests or deciding the correct test scope.
 - keep framework and application test intent separated
 - align changes with current fixture and CI behavior
 
+## Future Role Alignment
+
+This skill remains cross-cutting across future maintainer and template skill families. Test scope decisions should continue to follow the changed responsibility rather than the future skill taxonomy.
+
 ## Workflow
 
 1. decide whether the change is unit, integration, or cross-layer
@@ -40,3 +44,4 @@ Use this skill when implementing tests or deciding the correct test scope.
 - `docs/agent/libkoiki.md`
 - `docs/agent/app.md`
 - `docs/agent/auth-security.md`
+- `docs/agent/skills/future-role-alignment.md`

--- a/docs/authentication-api-guide.md
+++ b/docs/authentication-api-guide.md
@@ -1344,10 +1344,10 @@ app.add_middleware(
 
 ```bash
 # マイグレーション状態確認
-alembic current
+uv run --locked alembic -c components/koiki_ref_app/alembic.ini current
 
 # 最新マイグレーション適用
-alembic upgrade head
+uv run --locked alembic -c components/koiki_ref_app/alembic.ini upgrade head
 
 # データベース接続テスト
 python -c "

--- a/docs/dev/local_setup.md
+++ b/docs/dev/local_setup.md
@@ -56,16 +56,16 @@ root `pyproject.toml` の `tool.uv.workspace` と `tool.uv.sources` により、
 
 ### 4. アプリケーションの実行
 
-互換導線:
+正式な参照アプリ導線:
 
 ```powershell
 uv run --locked uvicorn koiki_ref_app.asgi:app --reload
 ```
 
-正式な参照アプリ導線:
+互換導線:
 
 ```powershell
-uv run uvicorn koiki_ref_app.asgi:app --reload
+uv run --locked uvicorn app.main:app --reload
 ```
 
 補足:

--- a/docs/dev/v0.7-directory-reorganization-tasks.ja.md
+++ b/docs/dev/v0.7-directory-reorganization-tasks.ja.md
@@ -1330,7 +1330,7 @@ Task:
 
 状態:
 
-- `未着手`
+- `完了`
 
 目的:
 
@@ -1345,11 +1345,18 @@ Task:
 
 - 現行運用を壊さずに、再編の布石が打てている
 
+実施結果:
+
+- `docs/agent/skills/future-role-alignment.md` を追加し、現行 skill 名と将来 role alignment の対応を整理した
+- 既存 skill 名は変更せず、Claude wrapper も維持する方針を明記した
+- 各 canonical `SKILL.md` に Future Role Alignment を追加した
+- `docs/agent/skills/README.md` から future role alignment 文書へ導線を追加した
+
 ### Task C-2: Skill Phase B 設計
 
 状態:
 
-- `未着手`
+- `完了`
 
 目的:
 
@@ -1364,6 +1371,20 @@ Task:
 検証:
 
 - 新構造完成後にすぐ skill 分割へ入れる
+
+実施結果:
+
+- `docs/agent/skills/future-role-alignment.md` に Phase B design を追加した
+- maintainer 系 skill 候補を整理した
+  - maintainer overview
+  - maintainer framework work
+  - maintainer template backend work
+  - maintainer template frontend work
+- template 系 skill 候補を整理した
+  - template overview
+  - template backend feature work
+  - template frontend feature work
+- root `frontend/` を upstream starter frontend として扱い、将来の template frontend guidance が持つべき責務を明記した
 
 ### Task C-3: MCP 再検討準備
 

--- a/docs/dev/v0.7-directory-reorganization-tasks.ja.md
+++ b/docs/dev/v0.7-directory-reorganization-tasks.ja.md
@@ -402,7 +402,7 @@ Task:
 
 状態:
 
-- `未着手`
+- `完了`
 
 推奨ブランチ:
 
@@ -430,7 +430,7 @@ Task:
 
 状態:
 
-- `未着手`
+- `完了`
 
 推奨ブランチ:
 
@@ -457,7 +457,7 @@ Task:
 
 状態:
 
-- `未着手`
+- `完了`
 
 推奨ブランチ:
 
@@ -484,7 +484,7 @@ Task:
 
 状態:
 
-- `未着手`
+- `完了`
 
 推奨ブランチ:
 
@@ -511,7 +511,7 @@ Task:
 
 状態:
 
-- `未着手`
+- `完了`
 
 推奨ブランチ:
 
@@ -1199,7 +1199,7 @@ Task:
 
 状態:
 
-- `未着手`
+- `完了`
 
 目的:
 
@@ -1219,11 +1219,28 @@ Task:
 
 - import / test / migration の最低限の実行確認が揃っている
 
+現状メモ:
+
+- `uv lock --check` は成功している
+- `DEBUG=true` と workspace-local `UV_CACHE_DIR` を指定した import 確認は成功している
+  - `import libkoiki`
+  - `import koiki_ref_app`
+  - `from app.main import app`
+  - `from koiki_ref_app.asgi import app`
+- `DEBUG=true` と workspace-local `UV_CACHE_DIR` を指定した `uv run --locked pytest --collect-only` は成功し、279 tests collected を確認した
+- Alembic は root から素の `alembic current` では失敗するため、現行標準は `uv run --locked alembic -c components/koiki_ref_app/alembic.ini ...`
+- Docker DB コンテナ `osskk_postgres_db` を起動し、ローカル実行側では `DATABASE_URL=postgresql+asyncpg://koiki_user:koiki_password@localhost:5432/koiki_todo_db` と `POSTGRES_SERVER=localhost` を指定して確認した
+- `uv run --locked alembic -c components/koiki_ref_app/alembic.ini current` は成功し、current revision が `20260228001 (head)` であることを確認した
+- `uv run --locked alembic -c components/koiki_ref_app/alembic.ini heads` は成功し、head が `20260228001 (head)` であることを確認した
+- `uv run --locked alembic -c components/koiki_ref_app/alembic.ini upgrade head` は成功した
+- `scripts/start-local-dev.ps1` と関連 docs は component 側 `alembic.ini` 指定へ更新済み
+- 実 DB に対する migration 確認は Docker DB 起動環境で完了した
+
 ### Task F-3: CI / GitHub Actions 実行確認と `uv` 化
 
 状態:
 
-- `未着手`
+- `進行中`
 
 目的:
 
@@ -1239,11 +1256,17 @@ Task:
 
 - `main` / `dev/v0.7` / `topic/*` 前提の CI が実行できる
 
+現状メモ:
+
+- `.github/workflows/ci.yml` は `uv lock --check`、`uv sync --locked --group dev --group test`、`uv run --locked pytest`、`uv tree --locked` 前提へ更新済み
+- local HEAD `3d4d35ca9ddad3803626e28de03a24246a9c5b66` に紐づく GitHub workflow run は未作成であることを確認した
+- GitHub Actions 上の実行結果確認は、変更を push / PR した後に回収する必要がある
+
 ### Task F-4: Docker / Compose 実起動確認
 
 状態:
 
-- `未着手`
+- `完了`
 
 目的:
 
@@ -1260,11 +1283,21 @@ Task:
 
 - コンテナ起動と migration 導線が新構造で成立している
 
+現状メモ:
+
+- Dockerfile / Compose の `uv` 化と build 確認は `v0.7-stage2-uv-follow-up-plan.ja.md` の FU-1 で完了済み
+- `docker compose up -d app` は成功し、`osskk_fastapi_app`、`osskk_postgres_db`、`osskk_keycloak` が healthy / running になった
+- backend 起動ログで DB 接続、`components/koiki_ref_app/alembic.ini` による Alembic migration、`koiki_ref_app.asgi:app` の Uvicorn 起動を確認した
+- `docker compose exec -T app python -c "import libkoiki, koiki_ref_app; from koiki_ref_app.asgi import app; print(...)"` は成功した
+- host から `http://localhost:8000/` と `http://localhost:8000/docs` はどちらも HTTP 200 を返した
+- `docker compose exec -T app alembic -c /app/components/koiki_ref_app/alembic.ini current` は成功し、current revision が `20260228001 (head)` であることを確認した
+- 実起動確認と migration 導線の確認は完了した
+
 ### Task F-5: 互換導線と入口ドキュメントの最終整理
 
 状態:
 
-- `未着手`
+- `完了`
 
 目的:
 
@@ -1283,6 +1316,13 @@ Task:
 検証:
 
 - 現行の入口ドキュメントと実コード構造に矛盾がない
+
+現状メモ:
+
+- root `main.py` は存在しない
+- `app/main.py` は `koiki_ref_app.asgi:app` への薄い compatibility wrapper として残している
+- root `AGENTS.md` と現行 setup docs は、`components/libkoiki` / `components/koiki_ref_app` を正本、root `app/` を互換 wrapper として説明している
+- 新規起動導線は `koiki_ref_app.asgi:app`、互換導線は `app.main:app` として整理済み
 
 ---
 

--- a/docs/dev/v0.7-stage2-uv-follow-up-plan.ja.md
+++ b/docs/dev/v0.7-stage2-uv-follow-up-plan.ja.md
@@ -365,7 +365,7 @@ Poetry 固有部分だけを PEP 517 / PEP 621 の別 backend へ置き換える
 - `docs/saml/SAML_SETUP.md` を `uv` 前提へ更新した
   - `poetry install` を `uv sync --locked` に変更
   - `poetry run uvicorn app.main:app` を `uv run --locked uvicorn koiki_ref_app.asgi:app` に変更
-  - `alembic upgrade head` を `uv run --locked alembic upgrade head` に変更
+  - `alembic upgrade head` を `uv run --locked alembic -c components/koiki_ref_app/alembic.ini upgrade head` に変更
 - `docs/saml/SAML_MIGRATION_GUIDE.md` の dependency sync 手順を `uv lock && uv sync --locked` に変更した
 - `docs/agent/skills/testing-plan.md` の test / smoke command を `uv run --locked` に変更した
 - `docs/backend-audit/LOG-09_LOGGING_OPERATIONS_RUNBOOK_ja.md` の運用 test command を `uv run --locked` と現行 component path に変更した

--- a/docs/saml/SAML_MIGRATION_GUIDE.md
+++ b/docs/saml/SAML_MIGRATION_GUIDE.md
@@ -179,7 +179,7 @@ python -c "from app.core.saml_config import SAMLSettings; print('OK')"
 
 **検証:**
 ```bash
-alembic upgrade head
+uv run --locked alembic -c components/koiki_ref_app/alembic.ini upgrade head
 # user_sso, saml_auth_flow テーブルが生成されること
 ```
 

--- a/docs/saml/SAML_SETUP.md
+++ b/docs/saml/SAML_SETUP.md
@@ -118,7 +118,7 @@ uv run --locked uvicorn koiki_ref_app.asgi:app --reload --host 0.0.0.0 --port 80
 
 ```bash
 # saml_auth_flow テーブルの作成
-uv run --locked alembic upgrade head
+uv run --locked alembic -c components/koiki_ref_app/alembic.ini upgrade head
 ```
 
 ## 認証フロー詳細
@@ -464,7 +464,7 @@ async function completeSamlLogin() {
 
 5. **データベースマイグレーション**:
    ```bash
-   uv run --locked alembic upgrade head  # saml_auth_flow テーブル作成
+   uv run --locked alembic -c components/koiki_ref_app/alembic.ini upgrade head  # saml_auth_flow テーブル作成
    ```
 
 ### 証明書管理

--- a/scripts/start-local-dev.ps1
+++ b/scripts/start-local-dev.ps1
@@ -30,7 +30,7 @@ $env:DEBUG = "True"
 
 # 3. Alembicでマイグレーションを実行
 Write-Host "データベースマイグレーションを実行中..." -ForegroundColor Yellow
-uv run --locked alembic upgrade head
+uv run --locked alembic -c components/koiki_ref_app/alembic.ini upgrade head
 
 # 4. アプリケーションを起動
 Write-Host "KOIKIフレームワークアプリケーションを起動中..." -ForegroundColor Green


### PR DESCRIPTION
## 対応内容

この PR では、v0.7 follow-up の実行確認結果整理と、将来の Agent Skills 再編に向けた設計整理を行いました。

### 1. v0.7 follow-up 実行確認

- `uv` / component 構成に合わせて Alembic 実行コマンドを整理しました。
  - `components/koiki_ref_app/alembic.ini` を明示指定する形に更新
  - `scripts/start-local-dev.ps1`
  - SAML / auth 関連 docs
- Docker DB コンテナを使った migration 確認を実施しました。
  - `alembic current`: `20260228001 (head)`
  - `alembic heads`: `20260228001 (head)`
  - `alembic upgrade head`: 成功
- `docker compose up -d app` による backend 実起動を確認しました。
  - `osskk_fastapi_app`: healthy
  - `osskk_postgres_db`: healthy
  - `osskk_keycloak`: running / healthy
  - `http://localhost:8000/`: 200
  - `http://localhost:8000/docs`: 200
- `docs/dev/v0.7-directory-reorganization-tasks.ja.md` に F-2 / F-4 / F-5 の結果を反映しました。
- F-3 は GitHub Actions の実 run 確認待ちとして `進行中` のまま残しています。

### 2. Agent Skills の future role alignment 整理

- `docs/agent/skills/future-role-alignment.md` を追加しました。
- 現行 skill と将来の maintainer / template 分離後の役割対応を整理しました。
- 既存 skill 名や Claude wrapper は変更していません。
- 各 canonical `SKILL.md` に `Future Role Alignment` セクションを追加しました。
- `docs/agent/skills/README.md` から新しい alignment 文書へ導線を追加しました。
- `docs/dev/v0.7-directory-reorganization-tasks.ja.md` に C-1 / C-2 の完了結果を反映しました。

## 検証

- `uv lock --check`: 成功
- `uv run --locked pytest --collect-only`: 279 tests collected
- `uv run --locked pytest tests/unit/agent_guidance/`: 13 passed
- Docker Compose backend 起動確認: 成功
- コンテナ内 Alembic current 確認: `20260228001 (head)`

## 残タスク

- F-3: GitHub Actions 実行結果確認
  - PR 作成後、`CI Pipeline / build-and-test` の成功を確認する
  - `uv lock --check`
  - `uv sync --locked --group dev --group test`
  - `uv run --locked pytest ...`
  - `uv tree --locked`
  - Poetry 前提 step が残っていないこと
