### PR TITLE
fix: update python analysis extraPaths for correct component paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,8 @@
     "python.defaultInterpreterPath": ".venv/Scripts/python.exe",
     "python.analysis.extraPaths": [
         "${workspaceFolder}/app",
-        "${workspaceFolder}/libkoiki"
+        "${workspaceFolder}/components/libkoiki/src",
+        "${workspaceFolder}/components/koiki_ref_app/src"
     ],
     "terminal.integrated.cwd": "${workspaceFolder}",
     "python.terminal.activateEnvironment": true,


### PR DESCRIPTION
## 対応内容

プロジェクトルートで VS Code / PowerShell が旧 `libkoiki/.venv` を拾ってしまう問題に対して、root workspace の現行構成に合わせた設定へ更新しました。

### 変更点

- `.vscode/settings.json` の `python.analysis.extraPaths` を現行 component 構成へ更新
  - 旧: `${workspaceFolder}/libkoiki`
  - 新: `${workspaceFolder}/components/libkoiki/src`
  - 新: `${workspaceFolder}/components/koiki_ref_app/src`
- `python.defaultInterpreterPath` は既存どおり `.venv/Scripts/python.exe` を維持
- Git 管理外の旧 `libkoiki/.venv` はローカルから削除済み

### 背景

root workspace では `.venv` が標準環境ですが、旧 `libkoiki/.venv` が残っていると VS Code や既存 PowerShell セッションが `VIRTUAL_ENV=libkoiki\.venv` を参照し、`uv sync` 時に以下の warning が出ます。

```text
VIRTUAL_ENV=libkoiki\.venv does not match the project environment path `.venv`
