### PR TITLE
Security dm08 task plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Read these files first:
 
 1. `docs/agent/boundaries.md`
 2. `docs/agent/architecture.md`
-3. `docs/agent/testing.md`
+3. `docs/agent/environment.md`
+4. `docs/agent/testing.md`
 
 Read these when relevant:
 

--- a/components/libkoiki/pyproject.toml
+++ b/components/libkoiki/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 # Enterprise-grade dependency management with strict versioning
 dependencies = [
     # Core Web Framework - Latest stable with security patches
-    "fastapi>=0.115.13,<0.116.0",         # Latest stable + starlette security fix
+    "fastapi>=0.136.1,<0.137.0",          # Updated to allow Starlette security fixes
     "uvicorn>=0.34.3,<0.35.0",            # Updated ASGI server (major performance improvements)
     
     # Database Layer - Critical for data integrity
@@ -33,8 +33,9 @@ dependencies = [
     "pydantic-settings>=2.10.0,<2.11.0",  # Latest available version
     
     # Security & Authentication - Highest priority for fixes
-    "PyJWT[crypto]>=2.11.0,<2.12.0",      # JWT library (replaces python-jose + jwcrypto)
+    "PyJWT[crypto]>=2.12.0,<2.13.0",      # JWT library (replaces python-jose + jwcrypto)
     "passlib[bcrypt]>=1.7.4,<1.8.0",      # Minor version locked
+    "bcrypt>=4.0.1,<4.1.0",               # passlib 1.7.4 expects bcrypt.__about__
     
     # HTTP Client & Communication
     "httpx>=0.28.1,<0.29.0",              # Updated HTTP client
@@ -54,8 +55,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.4.1,<8.5.0",
-    "pytest-asyncio>=1.0.0,<1.1.0",
+    "pytest>=9.0.3,<9.1.0",
+    "pytest-asyncio>=1.3.0,<1.4.0",
     "pytest-cov>=6.2.1,<7.0.0",
     "pytest-mock>=3.14.0,<4.0.0",
 ]

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -14,13 +14,15 @@ Start here when the task is not yet classified.
    - decide whether the change belongs in `components/libkoiki/` or `components/koiki_ref_app/`
 2. `architecture.md`
    - understand the repository structure and preferred layer flow
-3. `testing.md`
+3. `environment.md`
+   - account for agent-specific environment collisions before running validation
+4. `testing.md`
    - choose the correct validation scope
-4. `auth-security.md`
+5. `auth-security.md`
    - read for auth, permission, SSO, SAML, or security-sensitive work
-5. `libkoiki.md`
+6. `libkoiki.md`
    - read for reusable framework changes
-6. `app.md`
+7. `app.md`
    - read for business-specific application changes
 
 ## Operational Principles

--- a/docs/agent/environment.md
+++ b/docs/agent/environment.md
@@ -1,0 +1,48 @@
+# Agent Environment
+
+## Purpose
+
+This document records environment issues that can affect AI-agent validation in this repository.
+
+Read this before running commands that import application settings, execute tests, or sync dependencies.
+
+## Application Environment Variables
+
+Treat repository application settings as the source of truth.
+
+- `DEBUG` in KOIKI-FW is a boolean application setting.
+- Valid project values are boolean forms such as `True`, `False`, `true`, and `false`.
+- Do not reinterpret non-boolean values as application settings unless the project explicitly defines them.
+
+## Codex DEBUG Collision
+
+Codex sessions may inherit `DEBUG=release` in the process environment.
+
+This value is not defined by this repository and is not a KOIKI-FW application setting. It appears to come from the agent execution environment or its parent process, where `DEBUG=release` has a different meaning from `Settings.DEBUG: bool`.
+
+When this inherited value reaches `libkoiki.core.config.Settings`, Pydantic correctly treats it as invalid for a boolean field.
+
+For Codex validation only:
+
+- explicitly set `DEBUG=True` or `DEBUG=False` when running commands that import application settings
+- do not change application code to accept `release` as a boolean debug value
+- do not document `DEBUG=release` as a supported project configuration
+
+For normal local development:
+
+- use the repository `.env` files or explicit boolean environment values
+- run commands such as `uv sync` and `uv run ...` normally
+
+## uv Cache in Sandboxed Agents
+
+Codex sandboxed commands may be unable to access the user's default uv cache under `AppData\Local\uv\cache`.
+
+This is an agent sandbox permission issue, not a project dependency-management requirement.
+
+For Codex validation only, if the default cache is blocked:
+
+- rerun the same command with the required approval when appropriate
+- use a workspace-local `UV_CACHE_DIR` only as a temporary agent workaround
+- do not make `UV_CACHE_DIR=.uv-cache-codex` part of the normal developer workflow
+
+For normal local development, `uv sync` should be sufficient unless the local machine has an independent uv cache problem.

--- a/docs/dev/deferred-maintenance-tasks.ja.md
+++ b/docs/dev/deferred-maintenance-tasks.ja.md
@@ -5,6 +5,7 @@
 関連計画:
 
 - `docs/dev/deferred-maintenance-plan.ja.md`
+- `docs/dev/dm08-dm10-security-task-plan.ja.md`
 
 ## 1. タスク一覧
 
@@ -20,6 +21,7 @@
 | `DM-08` | P5 | security | `pip-audit` 検出依存を更新する | 単独 |
 | `DM-09` | P5 | security | Bandit false positive 方針を整理する | 単独 |
 | `DM-10` | P5 | security | SAML metadata XML parser を hardening する | 単独 |
+| `DM-11` | P5 | security | password hashing backend を `passlib` から `bcrypt` 直利用へ移行する | 単独 |
 
 ## 2. `DM-01` Settings.DATABASE_URL 組み立て復旧
 
@@ -515,6 +517,12 @@ uv lock --check
 
 優先度: `P5`
 
+状態: `完了`
+
+詳細実施計画:
+
+- `docs/dev/dm08-dm10-security-task-plan.ja.md`
+
 ### 目的
 
 `pip-audit` で検出済みの依存脆弱性を解消する。
@@ -548,9 +556,101 @@ uv lock --check
 uv run --locked pytest --collect-only components/libkoiki/tests components/koiki_ref_app/tests tests -m "not db_integration"
 ```
 
+### 実施結果
+
+実行日: 2026-05-03
+
+更新前の `pip-audit` 結果:
+
+- `pip 26.0.1`: `CVE-2026-3219`
+- `PyJWT 2.11.0`: `CVE-2026-32597`, fixed in `2.12.0`
+- `pytest 8.4.2`: `CVE-2025-71176`, fixed in `9.0.3`
+- `starlette 0.46.2`: `CVE-2025-54121`, fixed in `0.47.2`
+- `starlette 0.46.2`: `CVE-2025-62727`, fixed in `0.49.1`
+
+対応:
+
+- root `pyproject.toml` と `components/libkoiki/pyproject.toml` の dependency range を更新した
+  - `fastapi>=0.136.1,<0.137.0`
+  - `PyJWT[crypto]>=2.12.0,<2.13.0`
+  - `bcrypt>=4.0.1,<4.1.0`
+  - `pytest>=9.0.3,<9.1.0`
+  - `pytest-asyncio>=1.3.0,<1.4.0`
+- `uv.lock` を更新した
+  - `fastapi 0.115.14 -> 0.136.1`
+  - `starlette 0.46.2 -> 0.52.1`
+  - `PyJWT 2.11.0 -> 2.12.1`
+  - `bcrypt 4.3.0 -> 4.0.1`
+  - `pytest 8.4.2 -> 9.0.3`
+  - `pytest-asyncio 1.0.0 -> 1.3.0`
+  - `annotated-doc 0.0.4` が `fastapi` の dependency として追加された
+- コンテナ操作ログ点検で見つかった `passlib 1.7.4` / `bcrypt 4.1+` 互換 warning に対応した
+  - `passlib 1.7.4` は `bcrypt.__about__.__version__` を参照する
+  - `bcrypt 4.1+` では `__about__` がなく、ログイン時に `(trapped) error reading bcrypt version` traceback が出る
+  - 現行実装を維持し、`bcrypt` を `4.0.1` 系に固定して warning を解消した
+  - この対応は DM-08 の脆弱性対応中に見つかったログ品質問題への暫定対応であり、長期方針としては `passlib` 依存を見直す
+
+更新後の `pip-audit` 結果:
+
+- `PyJWT` / `pytest` / `starlette` の検出は解消
+- `bcrypt 4.0.1` 固定による新規検出はなし
+- 残件は `pip 26.0.1` の `CVE-2026-3219` のみ
+- `pip` の `CVE-2026-3219` は `pip-audit` 結果上 `Fix Versions` が空で、アプリケーション runtime dependency ではなく監査実行環境側 dependency として残件扱い
+- workspace package の `koiki-ref-app` / `libkoiki` は PyPI 上にないため `pip-audit` の skip reason として表示される
+
+検証結果:
+
+```text
+$env:UV_CACHE_DIR='.uv-cache-codex'
+$env:DEBUG='true'
+
+uv lock --check
+  成功
+
+uv sync --locked --group dev --group test --group security
+  成功
+
+uv run --locked pip-audit
+  pip 26.0.1 CVE-2026-3219 の 1 件のみ残存
+
+uv run --locked python -c "from libkoiki.core.security import get_password_hash, verify_password; ..."
+  hash / verify 成功
+  passlib / bcrypt 由来 traceback なし
+
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_user_service.py components/libkoiki/tests/unit/libkoiki/services/test_user_service_simple.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py
+  27 passed
+  既存の transaction mock RuntimeWarning は残る
+
+uv run --locked pytest --collect-only components/libkoiki/tests components/koiki_ref_app/tests tests -m "not db_integration"
+  249/286 tests collected, 37 deselected
+
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py
+  17 passed
+  既存の transaction mock RuntimeWarning は残る
+
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py components/koiki_ref_app/tests/unit/app/services/test_sso_service.py
+  38 passed
+
+uv run --locked pytest tests/unit/test_pyjwt_migration.py
+  33 passed
+  PyJWT 2.12.1 の短い HMAC test key に対する InsecureKeyLengthWarning は残る
+
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+  196 passed, 1 skipped, 11 deselected
+  既存の transaction mock RuntimeWarning と FastAPI / Starlette 更新に伴う HTTP_422_UNPROCESSABLE_ENTITY deprecation warning は残る
+```
+
+### 後続タスク
+
+- `DM-11`: `passlib 1.7.4` が古く、`bcrypt 4.1+` 以降の API 変更に追従していないため、v0.7.0 の土台整備として password hashing backend を `bcrypt` 直利用へ移行する
+
 ## 10. `DM-09` Bandit false positive 方針整理
 
 優先度: `P5`
+
+詳細実施計画:
+
+- `docs/dev/dm08-dm10-security-task-plan.ja.md`
 
 ### 目的
 
@@ -585,6 +685,10 @@ uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/s
 
 優先度: `P5`
 
+詳細実施計画:
+
+- `docs/dev/dm08-dm10-security-task-plan.ja.md`
+
 ### 目的
 
 外部 SAML metadata XML を扱う箇所を、標準 `xml.etree.ElementTree` からより安全な parser に寄せる。
@@ -617,7 +721,94 @@ uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_sam
 uv run --locked bandit -r components/koiki_ref_app/src/koiki_ref_app/services/saml_metadata_loader.py
 ```
 
-## 12. 推奨実行順
+## 12. `DM-11` password hashing backend の passlib 脱却
+
+優先度: `P5`
+
+状態: `未着手`
+
+### 目的
+
+`libkoiki.core.security` の password hashing backend を `passlib` 依存から `bcrypt` 直利用へ移行し、古い `passlib 1.7.4` と `bcrypt` の互換問題を根本解消する。
+
+### 判断経緯
+
+`DM-08` の依存脆弱性対応後、コンテナ実行ログでログイン時に次の warning / traceback が確認された。
+
+```text
+(trapped) error reading bcrypt version
+AttributeError: module 'bcrypt' has no attribute '__about__'
+```
+
+原因:
+
+- 現行実装は `libkoiki.core.security` で `passlib.context.CryptContext(schemes=["bcrypt"])` を使っている
+- `passlib 1.7.4` は `2020` 年リリースで止まっている
+- `passlib 1.7.4` は bcrypt backend 初期化時に `bcrypt.__about__.__version__` を参照する
+- `bcrypt 4.1+` では `__about__` が削除されているため、ログイン時に traceback が出る
+
+`DM-08` ではセキュリティ依存更新の差分を広げすぎないため、暫定的に `bcrypt>=4.0.1,<4.1.0` へ固定し、warning を解消した。
+
+ただし、この固定は根本対応ではない。`bcrypt` を古い互換範囲に留めるより、password hashing の薄い境界である `get_password_hash()` / `verify_password()` を `bcrypt` 直利用へ置き換える方が、v0.7.0 以降の保守性が高い。
+
+### 対象
+
+- `components/libkoiki/src/libkoiki/core/security.py`
+- `components/libkoiki/src/libkoiki/services/user_service.py`
+- `components/libkoiki/tests/unit/libkoiki/services/test_user_service.py`
+- `components/libkoiki/tests/unit/libkoiki/services/test_user_service_simple.py`
+- 必要に応じて auth / login security 関連テスト
+- root `pyproject.toml`
+- `components/libkoiki/pyproject.toml`
+- `uv.lock`
+
+### 作業
+
+- `libkoiki.core.security.get_password_hash()` を `bcrypt.hashpw()` / `bcrypt.gensalt()` ベースへ置き換える
+- `libkoiki.core.security.verify_password()` を `bcrypt.checkpw()` ベースへ置き換える
+- 既存の `$2b$...` bcrypt hash が検証できることを確認する
+- invalid hash / 破損 hash で例外が外へ漏れず、認証失敗として扱われることを確認する
+- `user_service.authenticate_user()` の存在しないユーザー向け dummy hash による timing protection を維持する
+- `passlib[bcrypt]` dependency を削除する
+- `bcrypt` dependency は `4.x` の現行互換範囲へ戻す
+
+### 完了条件
+
+- `passlib` が runtime dependency から消えている
+- `get_password_hash()` が `$2b$` 形式の bcrypt hash を生成する
+- `verify_password()` が既存 `$2b$` hash を検証できる
+- ユーザー作成 / パスワード更新 / ログインの既存挙動が維持される
+- 存在しないユーザーや invalid hash の認証失敗時にも timing protection が維持される
+- コンテナログで `passlib/handlers/bcrypt.py` 由来 traceback が発生しない
+
+### 検証
+
+```powershell
+$env:UV_CACHE_DIR='.uv-cache-codex'
+$env:DEBUG='true'
+uv lock --check
+uv run --locked python -c "from libkoiki.core.security import get_password_hash, verify_password; h=get_password_hash('TestPass123@'); print(h.startswith('$2b$'), verify_password('TestPass123@', h))"
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_user_service.py components/libkoiki/tests/unit/libkoiki/services/test_user_service_simple.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+uv run --locked pip-audit
+```
+
+コンテナ確認:
+
+```powershell
+.\start-docker.ps1 unified-prod-build
+.\start-docker.ps1 unified-prod
+docker logs koiki_app_prod_unified
+```
+
+確認観点:
+
+- password login が成功する
+- タスク管理アプリ操作が成功する
+- `passlib` / `bcrypt` 互換 traceback が出ない
+- `bcrypt` の新規 `pip-audit` 検出がない
+
+## 13. 推奨実行順
 
 1. `DM-01`
 2. `DM-02`
@@ -629,11 +820,12 @@ uv run --locked bandit -r components/koiki_ref_app/src/koiki_ref_app/services/sa
 8. `DM-08`
 9. `DM-09`
 10. `DM-10`
+11. `DM-11`
 
 `DM-01` と `DM-02` は、他タスクの前に小さく処理する。
 `DM-03` から `DM-05` は Pydantic v2 互換性としてまとめて扱えるが、差分が大きくなる場合は schema / service / logging に分ける。
 
-## 13. 共通 NG 条件
+## 14. 共通 NG 条件
 
 - import error
 - lock mismatch

--- a/docs/dev/dm08-dm10-security-task-plan.ja.md
+++ b/docs/dev/dm08-dm10-security-task-plan.ja.md
@@ -1,0 +1,324 @@
+# DM-08からDM-10 セキュリティ改修 実施計画
+
+作成日: 2026-05-03
+
+関連:
+
+- `docs/dev/deferred-maintenance-tasks.ja.md`
+- `docs/dev/deferred-maintenance-plan.ja.md`
+- `docs/security/SECURITY_AUDIT_COMMANDS.md`
+
+## 1. 結論
+
+`docs/dev/deferred-maintenance-tasks.ja.md` の `DM-08` から `DM-10` は、実施対象の方向性としては妥当だが、セキュリティ改修の実施計画としては不足している。
+
+不足している点:
+
+- 監査結果の記録先と、残件を許容する場合の判断基準が未定義
+- direct / transitive / dev tooling / runtime dependency の切り分け基準が弱い
+- FastAPI / Starlette など互換性影響が大きい更新の確認範囲が未定義
+- Bandit false positive を `# nosec` にする条件と、コード修正に回す条件が未定義
+- SAML metadata XML parser hardening の攻撃入力テストが未定義
+- セキュリティ修正後に最低限通すべき integration 寄りの検証範囲が弱い
+
+以降の計画は、`DM-08` から `DM-10` をそれぞれ単独 PR に分ける前提で、実装判断・記録・検証の粒度を補う。
+
+## 2. 共通方針
+
+### PR 境界
+
+- `DM-08`: 依存脆弱性対応のみ。`pyproject.toml` / `uv.lock` / 必要な互換修正に限定する。
+- `DM-09`: Bandit の分類、false positive 抑制、実リスク修正のみ。依存更新は含めない。
+- `DM-10`: SAML metadata XML parser hardening とテストのみ。関連 runtime dependency が不足する場合だけ依存定義を変更する。
+
+### 監査記録
+
+各タスクで、実行時点の結果をタスク本文または専用メモに残す。
+
+記録する内容:
+
+- 実行日
+- 実行コマンド
+- 検出件数
+- 対応した ID
+- 残件がある場合の理由
+- 次に確認すべき条件
+
+残件を許容できる条件:
+
+- 修正版が存在しない
+- transitive dependency で、上流の互換範囲を超える更新が必要
+- dev / security tooling のみで runtime impact がない
+- 実行環境由来で、アプリケーションの lockfile 変更では直せない
+
+許容する場合でも、CVE / advisory ID、影響範囲、再確認条件を残す。
+
+### 検証環境
+
+PowerShell:
+
+```powershell
+$env:UV_CACHE_DIR='.uv-cache-codex'
+$env:DEBUG='true'
+uv lock --check
+```
+
+DB integration は、DB 起動済みの場合のみ追加で実行する。
+
+```powershell
+.\scripts\run-db-integration-tests.ps1
+```
+
+## 3. `DM-08` pip-audit 検出依存更新
+
+### 目的
+
+`pip-audit` が検出する依存脆弱性を、runtime impact を優先して解消する。
+
+### 実施手順
+
+1. 現在の監査結果を JSON と通常出力で取得する。
+
+```powershell
+uv run --locked pip-audit --format=json --output=pip-audit-dm08-before.json
+uv run --locked pip-audit
+uv tree
+```
+
+2. 検出結果を分類する。
+
+- runtime direct dependency
+- runtime transitive dependency
+- dev / test / security group dependency
+- 実行環境側 dependency
+- 修正版なし
+
+3. 更新方針を決める。
+
+- direct dependency は `pyproject.toml` の上限範囲内で更新できるか確認する。
+- transitive dependency は、親 dependency の互換範囲を確認してから更新する。
+- FastAPI / Starlette / AnyIO / Pydantic 周辺は API・middleware・auth の回帰範囲を広めに取る。
+- `pip` 自体の検出は、プロジェクト lockfile で扱えるか、実行環境更新が必要かを分けて記録する。
+
+4. 依存を更新する。
+
+通常は次の順で進める。
+
+```powershell
+uv lock --upgrade-package <package>
+uv sync --locked --group dev --group test --group security
+uv lock --check
+```
+
+`pyproject.toml` の version range 変更が必要な場合のみ、`uv add` または手動編集後に `uv lock` を実行する。
+
+5. 更新後の監査結果を取得する。
+
+```powershell
+uv run --locked pip-audit --format=json --output=pip-audit-dm08-after.json
+uv run --locked pip-audit
+```
+
+### 完了条件
+
+- runtime dependency の修正可能な脆弱性が解消されている
+- 残件がある場合、ID・影響範囲・未対応理由・再確認条件が記録されている
+- `uv.lock` と `pyproject.toml` の整合性が取れている
+- FastAPI / Starlette 周辺を更新した場合、API / auth / middleware の主要テストが通っている
+
+### 最低検証
+
+```powershell
+uv lock --check
+uv run --locked pytest --collect-only components/libkoiki/tests components/koiki_ref_app/tests tests -m "not db_integration"
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py components/koiki_ref_app/tests/unit/app/services/test_sso_service.py
+```
+
+FastAPI / Starlette / middleware 変更が含まれる場合:
+
+```powershell
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+```
+
+## 4. `DM-09` Bandit false positive 方針整理
+
+### 目的
+
+Bandit の検出結果を、コード修正すべき実リスクと false positive に分ける。
+
+### 実施手順
+
+1. JSON と通常出力で現状を取得する。
+
+```powershell
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src -f json -o bandit-dm09-before.json
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level low
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level medium
+```
+
+2. 検出を分類する。
+
+- High: 原則コード修正。残す場合は明示レビュー必須。
+- Medium: 実リスク確認後、コード修正または局所 `# nosec`。
+- Low: false positive 方針に従って抑制可。
+
+3. false positive 抑制のルールを適用する。
+
+- `# nosec` は、該当行が定数・テスト専用値・既知の安全な fallback である場合に限定する。
+- `# nosec` を使う場合は、同じ行または直前コメントに理由を短く残す。
+- 広域除外は、同種の false positive が多数あり、局所抑制よりレビュー性が高い場合だけ検討する。
+- 実リスクを隠す恐れがある plugin 全体除外は避ける。
+
+4. 実リスクがあるものはコード修正する。
+
+想定例:
+
+- OAuth2 token type 定数に対する `B106`: secret ではない固定 token type なら局所 `# nosec`。
+- security event name 定数に対する `B105`: secret ではないログ分類名なら局所 `# nosec`。
+- logging fallback の `B110`: 例外握りつぶしが妥当か確認し、可能なら例外型を絞る。握りつぶしが設計上必要な場合は理由付き `# nosec`。
+
+5. 更新後の結果を取得する。
+
+```powershell
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src -f json -o bandit-dm09-after.json
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level medium
+```
+
+### 完了条件
+
+- High severity が残っていない
+- Medium severity の残件は理由付きでレビュー可能になっている
+- `# nosec` は局所的で、理由が追跡できる
+- 実リスクのある logging / exception handling はコード修正されている
+
+### 最低検証
+
+```powershell
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level medium
+uv run --locked pytest --collect-only components/libkoiki/tests components/koiki_ref_app/tests tests -m "not db_integration"
+```
+
+ログ sanitizer や auth 定数に触れた場合:
+
+```powershell
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/test_input_logging.py
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_login_security_service.py
+```
+
+## 5. `DM-10` SAML metadata XML parser hardening
+
+### 目的
+
+外部 SAML metadata XML の parse を、標準 `xml.etree.ElementTree` から安全な parser に置き換える。
+
+### 実施判断
+
+`defusedxml` を採用する。
+
+理由:
+
+- 対象は外部から取得した XML
+- `defusedxml` は既に `uv.lock` に存在する
+- runtime import が必要なため、直接 runtime dependency として `pyproject.toml` に追加されているか確認する
+
+`defusedxml` が transitive dependency のみの場合は、偶然の transitive dependency に依存せず、runtime dependency として明示する。
+
+### 実施手順
+
+1. 現状の XML parse 箇所を確認する。
+
+```powershell
+rg -n "xml\\.etree|ET\\.fromstring|defusedxml" components/koiki_ref_app/src/koiki_ref_app/services components/koiki_ref_app/tests -S
+```
+
+2. parser を置き換える。
+
+- `import xml.etree.ElementTree as ET` を `from defusedxml import ElementTree as ET` へ置き換える。
+- `ET.ParseError` に加えて、`defusedxml.common.DefusedXmlException` を logging / error handling の対象にする。
+- 複数箇所の `ET.fromstring` は、必要なら helper に集約する。
+- 既存の `error_type` logging 方針を維持し、raw exception message を structured log に出さない。
+
+3. 攻撃入力テストを追加する。
+
+追加候補:
+
+- DOCTYPE を含む metadata が拒否される
+- 外部 entity を含む metadata が拒否される
+- entity expansion 系の入力が拒否される
+- 拒否時のログが `error_type` のみで、raw XML や raw exception を含まない
+
+4. SAML metadata の通常処理が維持されることを確認する。
+
+- signing certificate 抽出
+- `entityID` 抽出
+- redirect / post の SSO URL 抽出
+- cache 更新と `force_refresh`
+
+### 完了条件
+
+- 外部 XML parse に標準 `xml.etree.ElementTree` を使っていない
+- 悪意ある XML 入力が拒否される
+- 既存の SAML metadata loader の正常系が壊れていない
+- logging sanitizer / error logging 方針が維持される
+- 必要な runtime dependency が明示されている
+
+### 最低検証
+
+```powershell
+uv lock --check
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_support_logging.py components/koiki_ref_app/tests/unit/app/services/test_saml_service.py
+uv run --locked bandit -r components/koiki_ref_app/src/koiki_ref_app/services/saml_metadata_loader.py
+```
+
+SAML metadata loader の通常処理テストが別ファイルにある場合は、それも追加で実行する。
+
+```powershell
+rg -n "SAMLMetadataLoader|get_signing_certificates|get_idp_entity_id|get_sso_service_url" components/koiki_ref_app/tests -S
+```
+
+## 6. 推奨順序
+
+1. `DM-10`
+2. `DM-09`
+3. `DM-08`
+
+理由:
+
+- `DM-10` は明確な実装リスクを直接下げられ、依存更新の影響範囲も限定的
+- `DM-09` は `DM-10` 後の Bandit 結果も含めて整理できる
+- `DM-08` は監査 DB と依存最新版に左右されるため、PR 作成直前の結果で判断するのがよい
+
+ただし、`pip-audit` で runtime の High / Critical が出ている場合は `DM-08` を最優先にする。
+
+## 7. 最終ゲート
+
+`DM-08` から `DM-10` の全完了後に、次を実行する。
+
+```powershell
+$env:UV_CACHE_DIR='.uv-cache-codex'
+$env:DEBUG='true'
+uv lock --check
+uv run --locked pip-audit
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level medium
+uv run --locked pytest --collect-only components/libkoiki/tests components/koiki_ref_app/tests tests -m "not db_integration"
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+```
+
+DB integration 実行環境がある場合:
+
+```powershell
+.\scripts\run-db-integration-tests.ps1
+```
+
+## 8. DM-08 から発生した後続タスク
+
+### `DM-11` password hashing backend の passlib 脱却
+
+`DM-08` の依存更新とコンテナ実行確認により、`passlib 1.7.4` / `bcrypt 4.1+` の互換 warning が確認された。
+
+`DM-08` では差分を依存脆弱性対応に留めるため、暫定的に `bcrypt>=4.0.1,<4.1.0` へ固定した。
+
+ただし、`passlib 1.7.4` は古く、`bcrypt` の新しい API 変更に追従していない。v0.7.0 の土台整備としては、`libkoiki.core.security.get_password_hash()` / `verify_password()` の境界を維持しつつ、内部実装を `bcrypt` 直利用へ移行するのが望ましい。
+
+詳細は `docs/dev/deferred-maintenance-tasks.ja.md` の `DM-11` を参照する。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 # All runtime dependencies with strict version control for production stability
 dependencies = [
     # Core Web Framework
-    "fastapi>=0.115.13,<0.116.0",           # Latest stable + starlette security fix
+    "fastapi>=0.136.1,<0.137.0",            # Updated to allow Starlette security fixes
     "uvicorn>=0.34.3,<0.35.0",              # Updated ASGI server (major performance improvements)
     
     # Database Layer (Python 3.13 compatible)
@@ -39,9 +39,9 @@ dependencies = [
     "email-validator>=2.2.0,<2.3.0",        # Updated for improved validation
     
     # Security & Authentication
-    "PyJWT[crypto]>=2.11.0,<2.12.0",        # JWT library (replaces python-jose + jwcrypto)
+    "PyJWT[crypto]>=2.12.0,<2.13.0",        # JWT library (replaces python-jose + jwcrypto)
     "passlib[bcrypt]>=1.7.4,<1.8.0",        # Minor version locked, compatible with bcrypt 4.x
-    "bcrypt>=4.1.3,<5.0.0",                  # Compatible bcrypt version
+    "bcrypt>=4.0.1,<4.1.0",                  # passlib 1.7.4 expects bcrypt.__about__
 
     # SAML Authentication
     "python3-saml>=1.16.0,<1.17.0",         # SAML 2.0 authentication support
@@ -73,8 +73,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     # Testing Framework (minor version locked)
-    "pytest>=8.4.1,<8.5.0",
-    "pytest-asyncio>=1.0.0,<1.1.0",
+    "pytest>=9.0.3,<9.1.0",
+    "pytest-asyncio>=1.3.0,<1.4.0",
     "pytest-cov>=6.2.1,<6.3.0",
     "pytest-mock>=3.14.0,<3.15.0",
     "PyYAML>=6.0,<7.0",
@@ -84,8 +84,8 @@ dev = [
     "bandit>=1.8.0,<1.9.0",              # Security linter (pydantic independent)
 ]
 test = [
-    "pytest>=8.4.1,<8.5.0",
-    "pytest-asyncio>=1.0.0,<1.1.0",
+    "pytest>=9.0.3,<9.1.0",
+    "pytest-asyncio>=1.3.0,<1.4.0",
     "pytest-cov>=6.2.1,<6.3.0",
     "pytest-mock>=3.14.0,<3.15.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -106,56 +115,21 @@ wheels = [
 
 [[package]]
 name = "bcrypt"
-version = "4.3.0"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", hash = "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18", size = 25697, upload-time = "2025-02-28T01:24:09.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/ae/3af7d006aacf513975fd1948a6b4d6f8b4a307f8a244e1a3d3774b297aad/bcrypt-4.0.1.tar.gz", hash = "sha256:27d375903ac8261cfe4047f6709d16f7d18d39b1ec92aaf72af989552a650ebd", size = 25498, upload-time = "2022-10-09T15:36:49.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/2c/3d44e853d1fe969d229bd58d39ae6902b3d924af0e2b5a60d17d4b809ded/bcrypt-4.3.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281", size = 483719, upload-time = "2025-02-28T01:22:34.539Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/e2/58ff6e2a22eca2e2cff5370ae56dba29d70b1ea6fc08ee9115c3ae367795/bcrypt-4.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5eeac541cefd0bb887a371ef73c62c3cd78535e4887b310626036a7c0a817bb", size = 272001, upload-time = "2025-02-28T01:22:38.078Z" },
-    { url = "https://files.pythonhosted.org/packages/37/1f/c55ed8dbe994b1d088309e366749633c9eb90d139af3c0a50c102ba68a1a/bcrypt-4.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59e1aa0e2cd871b08ca146ed08445038f42ff75968c7ae50d2fdd7860ade2180", size = 277451, upload-time = "2025-02-28T01:22:40.787Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/1c/794feb2ecf22fe73dcfb697ea7057f632061faceb7dcf0f155f3443b4d79/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0042b2e342e9ae3d2ed22727c1262f76cc4f345683b5c1715f0250cf4277294f", size = 272792, upload-time = "2025-02-28T01:22:43.144Z" },
-    { url = "https://files.pythonhosted.org/packages/13/b7/0b289506a3f3598c2ae2bdfa0ea66969812ed200264e3f61df77753eee6d/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74a8d21a09f5e025a9a23e7c0fd2c7fe8e7503e4d356c0a2c1486ba010619f09", size = 289752, upload-time = "2025-02-28T01:22:45.56Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/24/d0fb023788afe9e83cc118895a9f6c57e1044e7e1672f045e46733421fe6/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:0142b2cb84a009f8452c8c5a33ace5e3dfec4159e7735f5afe9a4d50a8ea722d", size = 277762, upload-time = "2025-02-28T01:22:47.023Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/38/cde58089492e55ac4ef6c49fea7027600c84fd23f7520c62118c03b4625e/bcrypt-4.3.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:12fa6ce40cde3f0b899729dbd7d5e8811cb892d31b6f7d0334a1f37748b789fd", size = 272384, upload-time = "2025-02-28T01:22:49.221Z" },
-    { url = "https://files.pythonhosted.org/packages/de/6a/d5026520843490cfc8135d03012a413e4532a400e471e6188b01b2de853f/bcrypt-4.3.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:5bd3cca1f2aa5dbcf39e2aa13dd094ea181f48959e1071265de49cc2b82525af", size = 277329, upload-time = "2025-02-28T01:22:51.603Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/a3/4fc5255e60486466c389e28c12579d2829b28a527360e9430b4041df4cf9/bcrypt-4.3.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:335a420cfd63fc5bc27308e929bee231c15c85cc4c496610ffb17923abf7f231", size = 305241, upload-time = "2025-02-28T01:22:53.283Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/15/2b37bc07d6ce27cc94e5b10fd5058900eb8fb11642300e932c8c82e25c4a/bcrypt-4.3.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:0e30e5e67aed0187a1764911af023043b4542e70a7461ad20e837e94d23e1d6c", size = 309617, upload-time = "2025-02-28T01:22:55.461Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/1f/99f65edb09e6c935232ba0430c8c13bb98cb3194b6d636e61d93fe60ac59/bcrypt-4.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3b8d62290ebefd49ee0b3ce7500f5dbdcf13b81402c05f6dafab9a1e1b27212f", size = 335751, upload-time = "2025-02-28T01:22:57.81Z" },
-    { url = "https://files.pythonhosted.org/packages/00/1b/b324030c706711c99769988fcb694b3cb23f247ad39a7823a78e361bdbb8/bcrypt-4.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef6630e0ec01376f59a006dc72918b1bf436c3b571b80fa1968d775fa02fe7d", size = 355965, upload-time = "2025-02-28T01:22:59.181Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/dd/20372a0579dd915dfc3b1cd4943b3bca431866fcb1dfdfd7518c3caddea6/bcrypt-4.3.0-cp313-cp313t-win32.whl", hash = "sha256:7a4be4cbf241afee43f1c3969b9103a41b40bcb3a3f467ab19f891d9bc4642e4", size = 155316, upload-time = "2025-02-28T01:23:00.763Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/52/45d969fcff6b5577c2bf17098dc36269b4c02197d551371c023130c0f890/bcrypt-4.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5c1949bf259a388863ced887c7861da1df681cb2388645766c89fdfd9004c669", size = 147752, upload-time = "2025-02-28T01:23:02.908Z" },
-    { url = "https://files.pythonhosted.org/packages/11/22/5ada0b9af72b60cbc4c9a399fdde4af0feaa609d27eb0adc61607997a3fa/bcrypt-4.3.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:f81b0ed2639568bf14749112298f9e4e2b28853dab50a8b357e31798686a036d", size = 498019, upload-time = "2025-02-28T01:23:05.838Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/8c/252a1edc598dc1ce57905be173328eda073083826955ee3c97c7ff5ba584/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:864f8f19adbe13b7de11ba15d85d4a428c7e2f344bac110f667676a0ff84924b", size = 279174, upload-time = "2025-02-28T01:23:07.274Z" },
-    { url = "https://files.pythonhosted.org/packages/29/5b/4547d5c49b85f0337c13929f2ccbe08b7283069eea3550a457914fc078aa/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e36506d001e93bffe59754397572f21bb5dc7c83f54454c990c74a468cd589e", size = 283870, upload-time = "2025-02-28T01:23:09.151Z" },
-    { url = "https://files.pythonhosted.org/packages/be/21/7dbaf3fa1745cb63f776bb046e481fbababd7d344c5324eab47f5ca92dd2/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:842d08d75d9fe9fb94b18b071090220697f9f184d4547179b60734846461ed59", size = 279601, upload-time = "2025-02-28T01:23:11.461Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/64/e042fc8262e971347d9230d9abbe70d68b0a549acd8611c83cebd3eaec67/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7c03296b85cb87db865d91da79bf63d5609284fc0cab9472fdd8367bbd830753", size = 297660, upload-time = "2025-02-28T01:23:12.989Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b8/6294eb84a3fef3b67c69b4470fcdd5326676806bf2519cda79331ab3c3a9/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:62f26585e8b219cdc909b6a0069efc5e4267e25d4a3770a364ac58024f62a761", size = 284083, upload-time = "2025-02-28T01:23:14.5Z" },
-    { url = "https://files.pythonhosted.org/packages/62/e6/baff635a4f2c42e8788fe1b1633911c38551ecca9a749d1052d296329da6/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:beeefe437218a65322fbd0069eb437e7c98137e08f22c4660ac2dc795c31f8bb", size = 279237, upload-time = "2025-02-28T01:23:16.686Z" },
-    { url = "https://files.pythonhosted.org/packages/39/48/46f623f1b0c7dc2e5de0b8af5e6f5ac4cc26408ac33f3d424e5ad8da4a90/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:97eea7408db3a5bcce4a55d13245ab3fa566e23b4c67cd227062bb49e26c585d", size = 283737, upload-time = "2025-02-28T01:23:18.897Z" },
-    { url = "https://files.pythonhosted.org/packages/49/8b/70671c3ce9c0fca4a6cc3cc6ccbaa7e948875a2e62cbd146e04a4011899c/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:191354ebfe305e84f344c5964c7cd5f924a3bfc5d405c75ad07f232b6dffb49f", size = 312741, upload-time = "2025-02-28T01:23:21.041Z" },
-    { url = "https://files.pythonhosted.org/packages/27/fb/910d3a1caa2d249b6040a5caf9f9866c52114d51523ac2fb47578a27faee/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:41261d64150858eeb5ff43c753c4b216991e0ae16614a308a15d909503617732", size = 316472, upload-time = "2025-02-28T01:23:23.183Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/cf/7cf3a05b66ce466cfb575dbbda39718d45a609daa78500f57fa9f36fa3c0/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:33752b1ba962ee793fa2b6321404bf20011fe45b9afd2a842139de3011898fef", size = 343606, upload-time = "2025-02-28T01:23:25.361Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/b8/e970ecc6d7e355c0d892b7f733480f4aa8509f99b33e71550242cf0b7e63/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:50e6e80a4bfd23a25f5c05b90167c19030cf9f87930f7cb2eacb99f45d1c3304", size = 362867, upload-time = "2025-02-28T01:23:26.875Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/97/8d3118efd8354c555a3422d544163f40d9f236be5b96c714086463f11699/bcrypt-4.3.0-cp38-abi3-win32.whl", hash = "sha256:67a561c4d9fb9465ec866177e7aebcad08fe23aaf6fbd692a6fab69088abfc51", size = 160589, upload-time = "2025-02-28T01:23:28.381Z" },
-    { url = "https://files.pythonhosted.org/packages/29/07/416f0b99f7f3997c69815365babbc2e8754181a4b1899d921b3c7d5b6f12/bcrypt-4.3.0-cp38-abi3-win_amd64.whl", hash = "sha256:584027857bc2843772114717a7490a37f68da563b3620f78a849bcb54dc11e62", size = 152794, upload-time = "2025-02-28T01:23:30.187Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/c1/3fa0e9e4e0bfd3fd77eb8b52ec198fd6e1fd7e9402052e43f23483f956dd/bcrypt-4.3.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0d3efb1157edebfd9128e4e46e2ac1a64e0c1fe46fb023158a407c7892b0f8c3", size = 498969, upload-time = "2025-02-28T01:23:31.945Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d4/755ce19b6743394787fbd7dff6bf271b27ee9b5912a97242e3caf125885b/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08bacc884fd302b611226c01014eca277d48f0a05187666bca23aac0dad6fe24", size = 279158, upload-time = "2025-02-28T01:23:34.161Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/5d/805ef1a749c965c46b28285dfb5cd272a7ed9fa971f970435a5133250182/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6746e6fec103fcd509b96bacdfdaa2fbde9a553245dbada284435173a6f1aef", size = 284285, upload-time = "2025-02-28T01:23:35.765Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/2b/698580547a4a4988e415721b71eb45e80c879f0fb04a62da131f45987b96/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:afe327968aaf13fc143a56a3360cb27d4ad0345e34da12c7290f1b00b8fe9a8b", size = 279583, upload-time = "2025-02-28T01:23:38.021Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/87/62e1e426418204db520f955ffd06f1efd389feca893dad7095bf35612eec/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9af79d322e735b1fc33404b5765108ae0ff232d4b54666d46730f8ac1a43676", size = 297896, upload-time = "2025-02-28T01:23:39.575Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/c6/8fedca4c2ada1b6e889c52d2943b2f968d3427e5d65f595620ec4c06fa2f/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f1e3ffa1365e8702dc48c8b360fef8d7afeca482809c5e45e653af82ccd088c1", size = 284492, upload-time = "2025-02-28T01:23:40.901Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/4d/c43332dcaaddb7710a8ff5269fcccba97ed3c85987ddaa808db084267b9a/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3004df1b323d10021fda07a813fd33e0fd57bef0e9a480bb143877f6cba996fe", size = 279213, upload-time = "2025-02-28T01:23:42.653Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/1e36379e169a7df3a14a1c160a49b7b918600a6008de43ff20d479e6f4b5/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:531457e5c839d8caea9b589a1bcfe3756b0547d7814e9ce3d437f17da75c32b0", size = 284162, upload-time = "2025-02-28T01:23:43.964Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/0a/644b2731194b0d7646f3210dc4d80c7fee3ecb3a1f791a6e0ae6bb8684e3/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:17a854d9a7a476a89dcef6c8bd119ad23e0f82557afbd2c442777a16408e614f", size = 312856, upload-time = "2025-02-28T01:23:46.011Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/62/2a871837c0bb6ab0c9a88bf54de0fc021a6a08832d4ea313ed92a669d437/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6fb1fd3ab08c0cbc6826a2e0447610c6f09e983a281b919ed721ad32236b8b23", size = 316726, upload-time = "2025-02-28T01:23:47.575Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/a1/9898ea3faac0b156d457fd73a3cb9c2855c6fd063e44b8522925cdd8ce46/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e965a9c1e9a393b8005031ff52583cedc15b7884fce7deb8b0346388837d6cfe", size = 343664, upload-time = "2025-02-28T01:23:49.059Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f2/71b4ed65ce38982ecdda0ff20c3ad1b15e71949c78b2c053df53629ce940/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505", size = 363128, upload-time = "2025-02-28T01:23:50.399Z" },
-    { url = "https://files.pythonhosted.org/packages/11/99/12f6a58eca6dea4be992d6c681b7ec9410a1d9f5cf368c61437e31daa879/bcrypt-4.3.0-cp39-abi3-win32.whl", hash = "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a", size = 160598, upload-time = "2025-02-28T01:23:51.775Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/cf/45fb5261ece3e6b9817d3d82b2f343a505fd58674a92577923bc500bd1aa/bcrypt-4.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b", size = 152799, upload-time = "2025-02-28T01:23:53.139Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b1/1289e21d710496b88340369137cc4c5f6ee036401190ea116a7b4ae6d32a/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a839320bf27d474e52ef8cb16449bb2ce0ba03ca9f44daba6d93fa1d8828e48a", size = 275103, upload-time = "2025-02-28T01:24:00.764Z" },
-    { url = "https://files.pythonhosted.org/packages/94/41/19be9fe17e4ffc5d10b7b67f10e459fc4eee6ffe9056a88de511920cfd8d/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:bdc6a24e754a555d7316fa4774e64c6c3997d27ed2d1964d55920c7c227bc4ce", size = 280513, upload-time = "2025-02-28T01:24:02.243Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/73/05687a9ef89edebdd8ad7474c16d8af685eb4591c3c38300bb6aad4f0076/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:55a935b8e9a1d2def0626c4269db3fcd26728cbff1e84f0341465c31c4ee56d8", size = 274685, upload-time = "2025-02-28T01:24:04.512Z" },
-    { url = "https://files.pythonhosted.org/packages/63/13/47bba97924ebe86a62ef83dc75b7c8a881d53c535f83e2c54c4bd701e05c/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:57967b7a28d855313a963aaea51bf6df89f833db4320da458e5b3c5ab6d4c938", size = 280110, upload-time = "2025-02-28T01:24:05.896Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f", size = 473446, upload-time = "2022-10-09T15:36:25.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0a/1582790232fef6c2aa201f345577306b8bfe465c2c665dec04c86a016879/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:08d2947c490093a11416df18043c27abe3921558d2c03e2076ccb28a116cb6d0", size = 583044, upload-time = "2022-10-09T15:37:09.447Z" },
+    { url = "https://files.pythonhosted.org/packages/41/16/49ff5146fb815742ad58cafb5034907aa7f166b1344d0ddd7fd1c818bd17/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0eaa47d4661c326bfc9d08d16debbc4edf78778e6aaba29c1bc7ce67214d4410", size = 583189, upload-time = "2022-10-09T15:37:10.69Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/48/fd2b197a9741fa790ba0b88a9b10b5e88e62ff5cf3e1bc96d8354d7ce613/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae88eca3024bb34bb3430f964beab71226e761f51b912de5133470b649d82344", size = 593473, upload-time = "2022-10-09T15:36:27.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/50/e683d8418974a602ba40899c8a5c38b3decaf5a4d36c32fc65dce454d8a8/bcrypt-4.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:a522427293d77e1c29e303fc282e2d71864579527a04ddcfda6d4f8396c6c36a", size = 593249, upload-time = "2022-10-09T15:36:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a7/ee4561fd9b78ca23c8e5591c150cc58626a5dfb169345ab18e1c2c664ee0/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fbdaec13c5105f0c4e5c52614d04f0bca5f5af007910daa8b6b12095edaa67b3", size = 583586, upload-time = "2022-10-09T15:37:11.962Z" },
+    { url = "https://files.pythonhosted.org/packages/64/fe/da28a5916128d541da0993328dc5cf4b43dfbf6655f2c7a2abe26ca2dc88/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ca3204d00d3cb2dfed07f2d74a25f12fc12f73e606fcaa6975d1f7ae69cacbb2", size = 593659, upload-time = "2022-10-09T15:36:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4f/3632a69ce344c1551f7c9803196b191a8181c6a1ad2362c225581ef0d383/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:089098effa1bc35dc055366740a067a2fc76987e8ec75349eb9484061c54f535", size = 613116, upload-time = "2022-10-09T15:37:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/87/69/edacb37481d360d06fc947dab5734aaf511acb7d1a1f9e2849454376c0f8/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e9a51bbfe7e9802b5f3508687758b564069ba937748ad7b9e890086290d2f79e", size = 624290, upload-time = "2022-10-09T15:36:31.251Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/6a534669890725cbb8c1fb4622019be31813c8edaa7b6d5b62fc9360a17e/bcrypt-4.0.1-cp36-abi3-win32.whl", hash = "sha256:2caffdae059e06ac23fce178d31b4a702f2a3264c20bfb5ff541b338194d8fab", size = 159428, upload-time = "2022-10-09T15:36:32.893Z" },
+    { url = "https://files.pythonhosted.org/packages/46/81/d8c22cd7e5e1c6a7d48e41a1d1d46c92f17dae70a54d9814f746e6027dec/bcrypt-4.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:8a68f4341daf7522fe8d73874de8906f3a339048ba406be6ddc1b3ccb16fc0d9", size = 152930, upload-time = "2022-10-09T15:36:34.635Z" },
 ]
 
 [[package]]
@@ -593,16 +567,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.14"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/53/8c38a874844a8b0fa10dd8adf3836ac154082cf88d3f22b544e9ceea0a15/fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739", size = 296263, upload-time = "2025-06-26T15:29:08.21Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/50/b1222562c6d270fea83e9c9075b8e8600b8479150a18e4516a6138b980d1/fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca", size = 95514, upload-time = "2025-06-26T15:29:06.49Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -795,9 +771,9 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.16.2,<1.17.0" },
     { name = "anyio", specifier = ">=4.9.0,<5.0.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
-    { name = "bcrypt", specifier = ">=4.1.3,<5.0.0" },
+    { name = "bcrypt", specifier = ">=4.0.1,<4.1.0" },
     { name = "email-validator", specifier = ">=2.2.0,<2.3.0" },
-    { name = "fastapi", specifier = ">=0.115.13,<0.116.0" },
+    { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "koiki-ref-app", editable = "components/koiki_ref_app" },
     { name = "libkoiki", editable = "components/libkoiki" },
@@ -807,7 +783,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.9,<2.10.0" },
     { name = "pydantic", specifier = ">=2.11.7,<2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.10.0,<2.11.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.11.0,<2.12.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<2.13.0" },
     { name = "python-multipart", specifier = ">=0.0.20,<0.1.0" },
     { name = "python3-saml", specifier = ">=1.16.0,<1.17.0" },
     { name = "redis", specifier = ">=6.2.0,<6.3.0" },
@@ -823,8 +799,8 @@ requires-dist = [
 dev = [
     { name = "bandit", specifier = ">=1.8.0,<1.9.0" },
     { name = "pip-audit", specifier = ">=2.9.0,<3.0.0" },
-    { name = "pytest", specifier = ">=8.4.1,<8.5.0" },
-    { name = "pytest-asyncio", specifier = ">=1.0.0,<1.1.0" },
+    { name = "pytest", specifier = ">=9.0.3,<9.1.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<1.4.0" },
     { name = "pytest-cov", specifier = ">=6.2.1,<6.3.0" },
     { name = "pytest-mock", specifier = ">=3.14.0,<3.15.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
@@ -834,8 +810,8 @@ security = [
     { name = "pip-audit", specifier = ">=2.9.0,<3.0.0" },
 ]
 test = [
-    { name = "pytest", specifier = ">=8.4.1,<8.5.0" },
-    { name = "pytest-asyncio", specifier = ">=1.0.0,<1.1.0" },
+    { name = "pytest", specifier = ">=9.0.3,<9.1.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<1.4.0" },
     { name = "pytest-cov", specifier = ">=6.2.1,<6.3.0" },
     { name = "pytest-mock", specifier = ">=3.14.0,<3.15.0" },
 ]
@@ -858,6 +834,7 @@ source = { editable = "components/libkoiki" }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "bcrypt" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "passlib", extra = ["bcrypt"] },
@@ -884,14 +861,15 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.16.2,<1.17.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
-    { name = "fastapi", specifier = ">=0.115.13,<0.116.0" },
+    { name = "bcrypt", specifier = ">=4.0.1,<4.1.0" },
+    { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4,<1.8.0" },
     { name = "pydantic", specifier = ">=2.11.7,<2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.10.0,<2.11.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.11.0,<2.12.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1,<8.5.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0.0,<1.1.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<2.13.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<9.1.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<1.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1,<7.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.0,<4.0.0" },
     { name = "redis", specifier = ">=6.2.0,<6.3.0" },
@@ -1496,11 +1474,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]
@@ -1519,7 +1497,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1528,21 +1506,22 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.0.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -1776,14 +1755,15 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "0.46.2"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

DM-08 のセキュリティ・脆弱性対応として、Python 依存関係を更新し、監査結果と実行確認結果をドキュメントへ反映しました。

## Changes

- FastAPI / Starlette / PyJWT / pytest / pytest-asyncio などを DM-08 対応版へ更新
- `passlib` と `bcrypt` の互換 warning 対応として、暫定的に `bcrypt==4.0.1` 系へ固定
- `uv.lock` を更新
- DM-08 の対応経緯、検証結果、残課題を `docs/dev/` に記録
- v0.7.0 向け残タスクとして、password hashing backend の `passlib` 脱却方針を記録
- Codex / Agent 実行環境での `DEBUG=release` 衝突と `UV_CACHE_DIR` 注意事項を `docs/agent/environment.md` に記録

## Validation

- `uv lock --check`
- `uv sync --locked --group dev --group test --group security`
- `uv run --locked pip-audit`
  - `pip 26.0.1` の既知 advisory のみ残存
  - 現時点で fix version なし
- 認証・ユーザー関連テスト
- SAML / SSO 関連テスト
- PyJWT migration 関連テスト
- component 非 DB 系テスト
- Docker production build
- Docker container 起動後のブラウザログイン・タスク管理サンプル操作
- コンテナログ確認
  - `fastapi 0.136.1`
  - `starlette 0.52.1`
  - `pyjwt 2.12.1`
  - `bcrypt 4.0.1`
  - `passlib` / `bcrypt` 互換 warning 解消を確認

## Notes

`passlib` の利用自体は今回の DM-08 では暫定維持とし、`bcrypt 4.0.1` 固定で warning を解消しています。

ただし、`libkoiki.core.security.get_password_hash()` / `verify_password()` が境界になっているため、v0.7.0 の追加タスクとして password hashing backend を `passlib` から `bcrypt` 直利用へ移行する方針を残タスク化しました。
