### PR TITLE
docs: clarify uv sync commands for local setup

### DIFF
--- a/docs/dev/local_setup.md
+++ b/docs/dev/local_setup.md
@@ -44,6 +44,18 @@ CI と同じ lockfile 固定の確認をしたい場合:
 uv sync --locked
 ```
 
+ローカルで開発・テスト用の依存まで lockfile に合わせる場合:
+
+```powershell
+uv sync --locked --group dev --group test
+```
+
+`pip-audit` や `bandit` などのセキュリティ検証も実行する場合:
+
+```powershell
+uv sync --locked --group dev --group test --group security
+```
+
 ### 3. ローカル component の取り込み
 
 追加の `pip install -e` は不要です。


### PR DESCRIPTION
## Summary

ローカル開発環境セットアップ手順に、lockfile 固定で依存グループを含めて同期する `uv sync` コマンドを追記しました。

## Changes

- `docs/dev/local_setup.md` に以下を追加
  - 通常の開発・テスト用依存同期
  - セキュリティ検証込みの依存同期

## Added Commands

```powershell
uv sync --locked --group dev --group test

# pip-audit / bandit などのセキュリティ検証も行う場合:
uv sync --locked --group dev --group test --group security
