### PR TITLE
chore: replace passlib password hashing with bcrypt

### DIFF
--- a/components/libkoiki/pyproject.toml
+++ b/components/libkoiki/pyproject.toml
@@ -34,8 +34,7 @@ dependencies = [
     
     # Security & Authentication - Highest priority for fixes
     "PyJWT[crypto]>=2.12.0,<2.13.0",      # JWT library (replaces python-jose + jwcrypto)
-    "passlib[bcrypt]>=1.7.4,<1.8.0",      # Minor version locked
-    "bcrypt>=4.0.1,<4.1.0",               # passlib 1.7.4 expects bcrypt.__about__
+    "bcrypt>=4.3.0,<5.0.0",               # Password hashing backend
     
     # HTTP Client & Communication
     "httpx>=0.28.1,<0.29.0",              # Updated HTTP client

--- a/components/libkoiki/src/libkoiki/core/security.py
+++ b/components/libkoiki/src/libkoiki/core/security.py
@@ -1,9 +1,9 @@
 # src/core/security.py
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Union, Annotated # Annotated をインポート
+import bcrypt
 import jwt
 from jwt.exceptions import InvalidTokenError
-from passlib.context import CryptContext
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import ValidationError
@@ -25,7 +25,7 @@ import hashlib
 logger = structlog.get_logger(__name__)
 
 # --- パスワードハッシュ化 ---
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+BCRYPT_ROUNDS = 12
 
 # --- OAuth2 スキーマ ---
 # tokenUrl は認証エンドポイントの相対パス
@@ -56,12 +56,23 @@ def create_access_token(subject: Union[str, Any], expires_delta: Optional[timede
 # --- パスワード検証 ---
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """平文パスワードとハッシュ化されたパスワードを比較検証します"""
-    return pwd_context.verify(plain_password, hashed_password)
+    try:
+        password_bytes = plain_password.encode("utf-8")
+        hash_bytes = hashed_password.encode("utf-8")
+        return bcrypt.checkpw(password_bytes, hash_bytes)
+    except (ValueError, TypeError) as e:
+        logger.warning(
+            "Password verification failed due to invalid hash format",
+            error_type=get_error_type_name(e),
+        )
+        return False
 
 # --- パスワードハッシュ化 ---
 def get_password_hash(password: str) -> str:
     """パスワードをハッシュ化します"""
-    return pwd_context.hash(password)
+    password_bytes = password.encode("utf-8")
+    hashed = bcrypt.hashpw(password_bytes, bcrypt.gensalt(rounds=BCRYPT_ROUNDS))
+    return hashed.decode("utf-8")
 
 # --- トークンからユーザーを取得 (依存性注入用) ---
 async def get_user_from_token(

--- a/components/libkoiki/tests/unit/core/test_security_password_hashing.py
+++ b/components/libkoiki/tests/unit/core/test_security_password_hashing.py
@@ -1,0 +1,34 @@
+import pytest
+
+from libkoiki.core.security import get_password_hash, verify_password
+
+
+def test_get_password_hash_generates_bcrypt_2b_hash():
+    hashed_password = get_password_hash("TestPass123@")
+
+    assert hashed_password.startswith("$2b$")
+    assert verify_password("TestPass123@", hashed_password) is True
+
+
+def test_verify_password_rejects_wrong_password():
+    hashed_password = get_password_hash("TestPass123@")
+
+    assert verify_password("WrongPass123@", hashed_password) is False
+
+
+def test_verify_password_accepts_existing_bcrypt_2b_hash():
+    existing_hash = "$2b$12$wIrq8gKvsFKwKGtv.0sPwuOPNR/8.ENqgArMHAm9MF2l58J37RFTC"
+
+    assert verify_password("TestPass123@", existing_hash) is True
+
+
+@pytest.mark.parametrize(
+    "invalid_hash",
+    [
+        "",
+        "not-a-bcrypt-hash",
+        "$2b$12$broken",
+    ],
+)
+def test_verify_password_returns_false_for_invalid_hash(invalid_hash):
+    assert verify_password("TestPass123@", invalid_hash) is False

--- a/components/libkoiki/tests/unit/libkoiki/services/test_user_service.py
+++ b/components/libkoiki/tests/unit/libkoiki/services/test_user_service.py
@@ -165,6 +165,34 @@ class TestUserService:
         
         # エラーメッセージを確認
         assert "already registered" in str(exc_info.value)
+
+    @patch('libkoiki.services.user_service.get_login_security_config')
+    @patch('libkoiki.services.user_service.verify_password')
+    @pytest.mark.asyncio
+    async def test_authenticate_user_not_found_uses_dummy_hash(
+        self,
+        mock_verify_password,
+        mock_get_login_security_config,
+        user_service,
+        mock_db_session,
+    ):
+        """存在しないユーザーでもdummy hashで検証し、タイミング保護を維持する"""
+        mock_get_login_security_config.return_value = MagicMock(min_response_time=0)
+        user_service.repository.get_by_email = AsyncMock(return_value=None)
+
+        result = await user_service.authenticate_user(
+            "missing@example.com",
+            "TestPass123@",
+            mock_db_session,
+        )
+
+        assert result is None
+        user_service.repository.set_session.assert_called_once_with(mock_db_session)
+        user_service.repository.get_by_email.assert_called_once_with("missing@example.com")
+        mock_verify_password.assert_called_once()
+        plain_password, dummy_hash = mock_verify_password.call_args.args
+        assert plain_password == "TestPass123@"
+        assert dummy_hash.startswith("$2b$")
     
     @patch('libkoiki.services.user_service.get_password_hash')
     @patch('libkoiki.services.user_service.check_password_complexity')

--- a/docs/dev/deferred-maintenance-tasks.ja.md
+++ b/docs/dev/deferred-maintenance-tasks.ja.md
@@ -742,7 +742,7 @@ uv run --locked bandit -r components/koiki_ref_app/src/koiki_ref_app/services/sa
 
 優先度: `P5`
 
-状態: `未着手`
+状態: `実装・コンテナ検証済み`
 
 ### 目的
 
@@ -772,6 +772,7 @@ AttributeError: module 'bcrypt' has no attribute '__about__'
 
 - `components/libkoiki/src/libkoiki/core/security.py`
 - `components/libkoiki/src/libkoiki/services/user_service.py`
+- `components/libkoiki/tests/unit/core/test_security_password_hashing.py`
 - `components/libkoiki/tests/unit/libkoiki/services/test_user_service.py`
 - `components/libkoiki/tests/unit/libkoiki/services/test_user_service_simple.py`
 - 必要に応じて auth / login security 関連テスト
@@ -788,6 +789,24 @@ AttributeError: module 'bcrypt' has no attribute '__about__'
 - `user_service.authenticate_user()` の存在しないユーザー向け dummy hash による timing protection を維持する
 - `passlib[bcrypt]` dependency を削除する
 - `bcrypt` dependency は `4.x` の現行互換範囲へ戻す
+
+### 実施結果
+
+- `libkoiki.core.security` の password hashing backend を `passlib.context.CryptContext` から `bcrypt` 直利用へ移行した
+  - `get_password_hash()` は `bcrypt.hashpw()` / `bcrypt.gensalt(rounds=12)` を使用する
+  - `verify_password()` は `bcrypt.checkpw()` を使用する
+  - invalid hash / 破損 hash は例外を外へ漏らさず `False` を返す
+- `user_service.authenticate_user()` の存在しないユーザー向け dummy hash timing protection を維持するテストを追加した
+- `components/libkoiki/tests/unit/core/test_security_password_hashing.py` を追加し、次を確認した
+  - `$2b$` bcrypt hash の生成
+  - 正しい password の検証成功
+  - 誤った password の検証失敗
+  - 既存 `$2b$` hash の検証互換
+  - invalid hash / 破損 hash で `False` を返すこと
+- root `pyproject.toml` と `components/libkoiki/pyproject.toml` から `passlib[bcrypt]` を削除した
+- `bcrypt` dependency を `bcrypt>=4.3.0,<5.0.0` に更新した
+  - `5.0.0` は 72 bytes 超過 password の扱いが変わるため、今回の移行では自動採用しない
+- `uv.lock` を更新し、`passlib 1.7.4` が削除され、`bcrypt 4.3.0` が解決された
 
 ### 完了条件
 
@@ -809,6 +828,68 @@ uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_use
 uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
 uv run --locked pip-audit
 ```
+
+実施済み結果:
+
+- `uv lock --check`: 成功
+- `uv sync --locked --group dev --group test --group security`: 成功
+  - `passlib==1.7.4` が uninstall された
+- `uv run --locked python -c "import importlib.util; print(importlib.util.find_spec('passlib'))"`
+  - `None`
+- `uv run --locked python -c "from libkoiki.core.security import get_password_hash, verify_password; h=get_password_hash('TestPass123@'); print(h.startswith('$2b$'), verify_password('TestPass123@', h), verify_password('WrongPass123@', h))"`
+  - `True True False`
+- 対象ユニットテスト:
+  - `components/libkoiki/tests/unit/core/test_security_password_hashing.py`
+  - `components/libkoiki/tests/unit/libkoiki/services/test_user_service.py`
+  - `components/libkoiki/tests/unit/libkoiki/services/test_user_service_simple.py`
+  - `components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py`
+  - `components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py`
+  - 結果: `34 passed`
+- 非 DB component テスト:
+  - `uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"`
+  - 結果: `204 passed, 1 skipped, 11 deselected`
+- `uv run --locked pip-audit`
+  - `pip 26.0.1 / CVE-2026-3219` のみ残存
+  - `bcrypt` の新規検出なし
+
+既存テストでは `AsyncMock` と transaction helper の組み合わせによる `RuntimeWarning` が残るが、DM-11 の password hashing 移行による失敗ではない。
+
+### コンテナ確認結果
+
+ローカル unified prod 構成で、次を実行した。
+
+```powershell
+.\start-docker.ps1 unified-prod-build
+.\start-docker.ps1 unified-prod
+```
+
+ブラウザ操作で次を確認した。
+
+- 通常 password login: 成功
+- タスク管理操作: 成功
+- 新規ユーザー登録 -> password login: 成功
+- OIDC / SSO login: 成功
+- SAML login: 成功
+
+パスワード変更は FastAPI Swagger UI 経由の導線のみで、prod container では Swagger UI が非表示のため未確認。
+
+アプリコンテナログ確認結果:
+
+- `Login successful`
+- `User registered successfully`
+- `SSO login successful`
+- `SAML login successful`
+- `/api/v1/auth/me`、`/api/v1/todos`、`/api/v1/todos` 更新系 request が成功
+
+次の DM-11 関連ログは確認されなかった。
+
+- `passlib`
+- `error reading bcrypt version`
+- `passlib/handlers/bcrypt.py`
+- `Traceback`
+- `Password verification failed`
+
+残る `InsecureKeyLengthWarning` は `JWT_SECRET` が HS256 推奨長 32 bytes 未満であることによる既知警告であり、DM-11 の password hashing backend 移行とは別件として扱う。
 
 コンテナ確認:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,7 @@ dependencies = [
     
     # Security & Authentication
     "PyJWT[crypto]>=2.12.0,<2.13.0",        # JWT library (replaces python-jose + jwcrypto)
-    "passlib[bcrypt]>=1.7.4,<1.8.0",        # Minor version locked, compatible with bcrypt 4.x
-    "bcrypt>=4.0.1,<4.1.0",                  # passlib 1.7.4 expects bcrypt.__about__
+    "bcrypt>=4.3.0,<5.0.0",                  # Password hashing backend
 
     # SAML Authentication
     "python3-saml>=1.16.0,<1.17.0",         # SAML 2.0 authentication support

--- a/uv.lock
+++ b/uv.lock
@@ -115,21 +115,56 @@ wheels = [
 
 [[package]]
 name = "bcrypt"
-version = "4.0.1"
+version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/ae/3af7d006aacf513975fd1948a6b4d6f8b4a307f8a244e1a3d3774b297aad/bcrypt-4.0.1.tar.gz", hash = "sha256:27d375903ac8261cfe4047f6709d16f7d18d39b1ec92aaf72af989552a650ebd", size = 25498, upload-time = "2022-10-09T15:36:49.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", hash = "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18", size = 25697, upload-time = "2025-02-28T01:24:09.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f", size = 473446, upload-time = "2022-10-09T15:36:25.481Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0a/1582790232fef6c2aa201f345577306b8bfe465c2c665dec04c86a016879/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:08d2947c490093a11416df18043c27abe3921558d2c03e2076ccb28a116cb6d0", size = 583044, upload-time = "2022-10-09T15:37:09.447Z" },
-    { url = "https://files.pythonhosted.org/packages/41/16/49ff5146fb815742ad58cafb5034907aa7f166b1344d0ddd7fd1c818bd17/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0eaa47d4661c326bfc9d08d16debbc4edf78778e6aaba29c1bc7ce67214d4410", size = 583189, upload-time = "2022-10-09T15:37:10.69Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/48/fd2b197a9741fa790ba0b88a9b10b5e88e62ff5cf3e1bc96d8354d7ce613/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae88eca3024bb34bb3430f964beab71226e761f51b912de5133470b649d82344", size = 593473, upload-time = "2022-10-09T15:36:27.195Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/50/e683d8418974a602ba40899c8a5c38b3decaf5a4d36c32fc65dce454d8a8/bcrypt-4.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:a522427293d77e1c29e303fc282e2d71864579527a04ddcfda6d4f8396c6c36a", size = 593249, upload-time = "2022-10-09T15:36:28.481Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/a7/ee4561fd9b78ca23c8e5591c150cc58626a5dfb169345ab18e1c2c664ee0/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fbdaec13c5105f0c4e5c52614d04f0bca5f5af007910daa8b6b12095edaa67b3", size = 583586, upload-time = "2022-10-09T15:37:11.962Z" },
-    { url = "https://files.pythonhosted.org/packages/64/fe/da28a5916128d541da0993328dc5cf4b43dfbf6655f2c7a2abe26ca2dc88/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ca3204d00d3cb2dfed07f2d74a25f12fc12f73e606fcaa6975d1f7ae69cacbb2", size = 593659, upload-time = "2022-10-09T15:36:30.049Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/4f/3632a69ce344c1551f7c9803196b191a8181c6a1ad2362c225581ef0d383/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:089098effa1bc35dc055366740a067a2fc76987e8ec75349eb9484061c54f535", size = 613116, upload-time = "2022-10-09T15:37:14.107Z" },
-    { url = "https://files.pythonhosted.org/packages/87/69/edacb37481d360d06fc947dab5734aaf511acb7d1a1f9e2849454376c0f8/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e9a51bbfe7e9802b5f3508687758b564069ba937748ad7b9e890086290d2f79e", size = 624290, upload-time = "2022-10-09T15:36:31.251Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ca/6a534669890725cbb8c1fb4622019be31813c8edaa7b6d5b62fc9360a17e/bcrypt-4.0.1-cp36-abi3-win32.whl", hash = "sha256:2caffdae059e06ac23fce178d31b4a702f2a3264c20bfb5ff541b338194d8fab", size = 159428, upload-time = "2022-10-09T15:36:32.893Z" },
-    { url = "https://files.pythonhosted.org/packages/46/81/d8c22cd7e5e1c6a7d48e41a1d1d46c92f17dae70a54d9814f746e6027dec/bcrypt-4.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:8a68f4341daf7522fe8d73874de8906f3a339048ba406be6ddc1b3ccb16fc0d9", size = 152930, upload-time = "2022-10-09T15:36:34.635Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2c/3d44e853d1fe969d229bd58d39ae6902b3d924af0e2b5a60d17d4b809ded/bcrypt-4.3.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281", size = 483719, upload-time = "2025-02-28T01:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e2/58ff6e2a22eca2e2cff5370ae56dba29d70b1ea6fc08ee9115c3ae367795/bcrypt-4.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5eeac541cefd0bb887a371ef73c62c3cd78535e4887b310626036a7c0a817bb", size = 272001, upload-time = "2025-02-28T01:22:38.078Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1f/c55ed8dbe994b1d088309e366749633c9eb90d139af3c0a50c102ba68a1a/bcrypt-4.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59e1aa0e2cd871b08ca146ed08445038f42ff75968c7ae50d2fdd7860ade2180", size = 277451, upload-time = "2025-02-28T01:22:40.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/1c/794feb2ecf22fe73dcfb697ea7057f632061faceb7dcf0f155f3443b4d79/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:0042b2e342e9ae3d2ed22727c1262f76cc4f345683b5c1715f0250cf4277294f", size = 272792, upload-time = "2025-02-28T01:22:43.144Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b7/0b289506a3f3598c2ae2bdfa0ea66969812ed200264e3f61df77753eee6d/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74a8d21a09f5e025a9a23e7c0fd2c7fe8e7503e4d356c0a2c1486ba010619f09", size = 289752, upload-time = "2025-02-28T01:22:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/24/d0fb023788afe9e83cc118895a9f6c57e1044e7e1672f045e46733421fe6/bcrypt-4.3.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:0142b2cb84a009f8452c8c5a33ace5e3dfec4159e7735f5afe9a4d50a8ea722d", size = 277762, upload-time = "2025-02-28T01:22:47.023Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/38/cde58089492e55ac4ef6c49fea7027600c84fd23f7520c62118c03b4625e/bcrypt-4.3.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:12fa6ce40cde3f0b899729dbd7d5e8811cb892d31b6f7d0334a1f37748b789fd", size = 272384, upload-time = "2025-02-28T01:22:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/d5026520843490cfc8135d03012a413e4532a400e471e6188b01b2de853f/bcrypt-4.3.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:5bd3cca1f2aa5dbcf39e2aa13dd094ea181f48959e1071265de49cc2b82525af", size = 277329, upload-time = "2025-02-28T01:22:51.603Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a3/4fc5255e60486466c389e28c12579d2829b28a527360e9430b4041df4cf9/bcrypt-4.3.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:335a420cfd63fc5bc27308e929bee231c15c85cc4c496610ffb17923abf7f231", size = 305241, upload-time = "2025-02-28T01:22:53.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/15/2b37bc07d6ce27cc94e5b10fd5058900eb8fb11642300e932c8c82e25c4a/bcrypt-4.3.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:0e30e5e67aed0187a1764911af023043b4542e70a7461ad20e837e94d23e1d6c", size = 309617, upload-time = "2025-02-28T01:22:55.461Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/1f/99f65edb09e6c935232ba0430c8c13bb98cb3194b6d636e61d93fe60ac59/bcrypt-4.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3b8d62290ebefd49ee0b3ce7500f5dbdcf13b81402c05f6dafab9a1e1b27212f", size = 335751, upload-time = "2025-02-28T01:22:57.81Z" },
+    { url = "https://files.pythonhosted.org/packages/00/1b/b324030c706711c99769988fcb694b3cb23f247ad39a7823a78e361bdbb8/bcrypt-4.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef6630e0ec01376f59a006dc72918b1bf436c3b571b80fa1968d775fa02fe7d", size = 355965, upload-time = "2025-02-28T01:22:59.181Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/20372a0579dd915dfc3b1cd4943b3bca431866fcb1dfdfd7518c3caddea6/bcrypt-4.3.0-cp313-cp313t-win32.whl", hash = "sha256:7a4be4cbf241afee43f1c3969b9103a41b40bcb3a3f467ab19f891d9bc4642e4", size = 155316, upload-time = "2025-02-28T01:23:00.763Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/52/45d969fcff6b5577c2bf17098dc36269b4c02197d551371c023130c0f890/bcrypt-4.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5c1949bf259a388863ced887c7861da1df681cb2388645766c89fdfd9004c669", size = 147752, upload-time = "2025-02-28T01:23:02.908Z" },
+    { url = "https://files.pythonhosted.org/packages/11/22/5ada0b9af72b60cbc4c9a399fdde4af0feaa609d27eb0adc61607997a3fa/bcrypt-4.3.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:f81b0ed2639568bf14749112298f9e4e2b28853dab50a8b357e31798686a036d", size = 498019, upload-time = "2025-02-28T01:23:05.838Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8c/252a1edc598dc1ce57905be173328eda073083826955ee3c97c7ff5ba584/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:864f8f19adbe13b7de11ba15d85d4a428c7e2f344bac110f667676a0ff84924b", size = 279174, upload-time = "2025-02-28T01:23:07.274Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5b/4547d5c49b85f0337c13929f2ccbe08b7283069eea3550a457914fc078aa/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e36506d001e93bffe59754397572f21bb5dc7c83f54454c990c74a468cd589e", size = 283870, upload-time = "2025-02-28T01:23:09.151Z" },
+    { url = "https://files.pythonhosted.org/packages/be/21/7dbaf3fa1745cb63f776bb046e481fbababd7d344c5324eab47f5ca92dd2/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:842d08d75d9fe9fb94b18b071090220697f9f184d4547179b60734846461ed59", size = 279601, upload-time = "2025-02-28T01:23:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/64/e042fc8262e971347d9230d9abbe70d68b0a549acd8611c83cebd3eaec67/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7c03296b85cb87db865d91da79bf63d5609284fc0cab9472fdd8367bbd830753", size = 297660, upload-time = "2025-02-28T01:23:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b8/6294eb84a3fef3b67c69b4470fcdd5326676806bf2519cda79331ab3c3a9/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:62f26585e8b219cdc909b6a0069efc5e4267e25d4a3770a364ac58024f62a761", size = 284083, upload-time = "2025-02-28T01:23:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e6/baff635a4f2c42e8788fe1b1633911c38551ecca9a749d1052d296329da6/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:beeefe437218a65322fbd0069eb437e7c98137e08f22c4660ac2dc795c31f8bb", size = 279237, upload-time = "2025-02-28T01:23:16.686Z" },
+    { url = "https://files.pythonhosted.org/packages/39/48/46f623f1b0c7dc2e5de0b8af5e6f5ac4cc26408ac33f3d424e5ad8da4a90/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:97eea7408db3a5bcce4a55d13245ab3fa566e23b4c67cd227062bb49e26c585d", size = 283737, upload-time = "2025-02-28T01:23:18.897Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8b/70671c3ce9c0fca4a6cc3cc6ccbaa7e948875a2e62cbd146e04a4011899c/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:191354ebfe305e84f344c5964c7cd5f924a3bfc5d405c75ad07f232b6dffb49f", size = 312741, upload-time = "2025-02-28T01:23:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fb/910d3a1caa2d249b6040a5caf9f9866c52114d51523ac2fb47578a27faee/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:41261d64150858eeb5ff43c753c4b216991e0ae16614a308a15d909503617732", size = 316472, upload-time = "2025-02-28T01:23:23.183Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cf/7cf3a05b66ce466cfb575dbbda39718d45a609daa78500f57fa9f36fa3c0/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:33752b1ba962ee793fa2b6321404bf20011fe45b9afd2a842139de3011898fef", size = 343606, upload-time = "2025-02-28T01:23:25.361Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b8/e970ecc6d7e355c0d892b7f733480f4aa8509f99b33e71550242cf0b7e63/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:50e6e80a4bfd23a25f5c05b90167c19030cf9f87930f7cb2eacb99f45d1c3304", size = 362867, upload-time = "2025-02-28T01:23:26.875Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/97/8d3118efd8354c555a3422d544163f40d9f236be5b96c714086463f11699/bcrypt-4.3.0-cp38-abi3-win32.whl", hash = "sha256:67a561c4d9fb9465ec866177e7aebcad08fe23aaf6fbd692a6fab69088abfc51", size = 160589, upload-time = "2025-02-28T01:23:28.381Z" },
+    { url = "https://files.pythonhosted.org/packages/29/07/416f0b99f7f3997c69815365babbc2e8754181a4b1899d921b3c7d5b6f12/bcrypt-4.3.0-cp38-abi3-win_amd64.whl", hash = "sha256:584027857bc2843772114717a7490a37f68da563b3620f78a849bcb54dc11e62", size = 152794, upload-time = "2025-02-28T01:23:30.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c1/3fa0e9e4e0bfd3fd77eb8b52ec198fd6e1fd7e9402052e43f23483f956dd/bcrypt-4.3.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0d3efb1157edebfd9128e4e46e2ac1a64e0c1fe46fb023158a407c7892b0f8c3", size = 498969, upload-time = "2025-02-28T01:23:31.945Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d4/755ce19b6743394787fbd7dff6bf271b27ee9b5912a97242e3caf125885b/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08bacc884fd302b611226c01014eca277d48f0a05187666bca23aac0dad6fe24", size = 279158, upload-time = "2025-02-28T01:23:34.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5d/805ef1a749c965c46b28285dfb5cd272a7ed9fa971f970435a5133250182/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6746e6fec103fcd509b96bacdfdaa2fbde9a553245dbada284435173a6f1aef", size = 284285, upload-time = "2025-02-28T01:23:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/698580547a4a4988e415721b71eb45e80c879f0fb04a62da131f45987b96/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:afe327968aaf13fc143a56a3360cb27d4ad0345e34da12c7290f1b00b8fe9a8b", size = 279583, upload-time = "2025-02-28T01:23:38.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/87/62e1e426418204db520f955ffd06f1efd389feca893dad7095bf35612eec/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9af79d322e735b1fc33404b5765108ae0ff232d4b54666d46730f8ac1a43676", size = 297896, upload-time = "2025-02-28T01:23:39.575Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c6/8fedca4c2ada1b6e889c52d2943b2f968d3427e5d65f595620ec4c06fa2f/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f1e3ffa1365e8702dc48c8b360fef8d7afeca482809c5e45e653af82ccd088c1", size = 284492, upload-time = "2025-02-28T01:23:40.901Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/4d/c43332dcaaddb7710a8ff5269fcccba97ed3c85987ddaa808db084267b9a/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3004df1b323d10021fda07a813fd33e0fd57bef0e9a480bb143877f6cba996fe", size = 279213, upload-time = "2025-02-28T01:23:42.653Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/1e36379e169a7df3a14a1c160a49b7b918600a6008de43ff20d479e6f4b5/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:531457e5c839d8caea9b589a1bcfe3756b0547d7814e9ce3d437f17da75c32b0", size = 284162, upload-time = "2025-02-28T01:23:43.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0a/644b2731194b0d7646f3210dc4d80c7fee3ecb3a1f791a6e0ae6bb8684e3/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:17a854d9a7a476a89dcef6c8bd119ad23e0f82557afbd2c442777a16408e614f", size = 312856, upload-time = "2025-02-28T01:23:46.011Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/62/2a871837c0bb6ab0c9a88bf54de0fc021a6a08832d4ea313ed92a669d437/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6fb1fd3ab08c0cbc6826a2e0447610c6f09e983a281b919ed721ad32236b8b23", size = 316726, upload-time = "2025-02-28T01:23:47.575Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a1/9898ea3faac0b156d457fd73a3cb9c2855c6fd063e44b8522925cdd8ce46/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e965a9c1e9a393b8005031ff52583cedc15b7884fce7deb8b0346388837d6cfe", size = 343664, upload-time = "2025-02-28T01:23:49.059Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/71b4ed65ce38982ecdda0ff20c3ad1b15e71949c78b2c053df53629ce940/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505", size = 363128, upload-time = "2025-02-28T01:23:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/12f6a58eca6dea4be992d6c681b7ec9410a1d9f5cf368c61437e31daa879/bcrypt-4.3.0-cp39-abi3-win32.whl", hash = "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a", size = 160598, upload-time = "2025-02-28T01:23:51.775Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/cf/45fb5261ece3e6b9817d3d82b2f343a505fd58674a92577923bc500bd1aa/bcrypt-4.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b", size = 152799, upload-time = "2025-02-28T01:23:53.139Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b1/1289e21d710496b88340369137cc4c5f6ee036401190ea116a7b4ae6d32a/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a839320bf27d474e52ef8cb16449bb2ce0ba03ca9f44daba6d93fa1d8828e48a", size = 275103, upload-time = "2025-02-28T01:24:00.764Z" },
+    { url = "https://files.pythonhosted.org/packages/94/41/19be9fe17e4ffc5d10b7b67f10e459fc4eee6ffe9056a88de511920cfd8d/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:bdc6a24e754a555d7316fa4774e64c6c3997d27ed2d1964d55920c7c227bc4ce", size = 280513, upload-time = "2025-02-28T01:24:02.243Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/73/05687a9ef89edebdd8ad7474c16d8af685eb4591c3c38300bb6aad4f0076/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:55a935b8e9a1d2def0626c4269db3fcd26728cbff1e84f0341465c31c4ee56d8", size = 274685, upload-time = "2025-02-28T01:24:04.512Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/47bba97924ebe86a62ef83dc75b7c8a881d53c535f83e2c54c4bd701e05c/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:57967b7a28d855313a963aaea51bf6df89f833db4320da458e5b3c5ab6d4c938", size = 280110, upload-time = "2025-02-28T01:24:05.896Z" },
 ]
 
 [[package]]
@@ -727,7 +762,6 @@ dependencies = [
     { name = "koiki-ref-app" },
     { name = "libkoiki" },
     { name = "limits" },
-    { name = "passlib", extra = ["bcrypt"] },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -771,14 +805,13 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.16.2,<1.17.0" },
     { name = "anyio", specifier = ">=4.9.0,<5.0.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
-    { name = "bcrypt", specifier = ">=4.0.1,<4.1.0" },
+    { name = "bcrypt", specifier = ">=4.3.0,<5.0.0" },
     { name = "email-validator", specifier = ">=2.2.0,<2.3.0" },
     { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "koiki-ref-app", editable = "components/koiki_ref_app" },
     { name = "libkoiki", editable = "components/libkoiki" },
     { name = "limits", specifier = ">=5.4.0,<5.5.0" },
-    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4,<1.8.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0,<7.2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9,<2.10.0" },
     { name = "pydantic", specifier = ">=2.11.7,<2.12.0" },
@@ -841,7 +874,6 @@ dependencies = [
     { name = "bcrypt" },
     { name = "fastapi" },
     { name = "httpx" },
-    { name = "passlib", extra = ["bcrypt"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -865,10 +897,9 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.16.2,<1.17.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
-    { name = "bcrypt", specifier = ">=4.0.1,<4.1.0" },
+    { name = "bcrypt", specifier = ">=4.3.0,<5.0.0" },
     { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
-    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4,<1.8.0" },
     { name = "pydantic", specifier = ">=2.11.7,<2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.10.0,<2.11.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<2.13.0" },
@@ -1189,20 +1220,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "passlib"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
-]
-
-[package.optional-dependencies]
-bcrypt = [
-    { name = "bcrypt" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

DM-11 として、password hashing backend を `passlib` から `bcrypt` 直利用へ移行しました。

DM-08 では `passlib 1.7.4` と `bcrypt 4.1+` の互換 warning を避けるため `bcrypt<4.1.0` に暫定固定していましたが、本 PR で `passlib` 依存を削除し、根本対応しています。

## Changes

- `libkoiki.core.security.get_password_hash()` を `bcrypt.hashpw()` / `bcrypt.gensalt()` ベースへ変更
- `libkoiki.core.security.verify_password()` を `bcrypt.checkpw()` ベースへ変更
- invalid hash / 破損 hash では例外を外へ漏らさず `False` を返すように変更
- `passlib[bcrypt]` dependency を削除
- `bcrypt` を `>=4.3.0,<5.0.0` に更新
- `uv.lock` 更新
  - `bcrypt 4.0.1 -> 4.3.0`
  - `passlib 1.7.4` 削除
- password hashing helper の単体テストを追加
- 存在しないユーザー認証時の dummy hash timing protection を維持するテストを追加
- DM-11 の実施結果・検証結果を `docs/dev/deferred-maintenance-tasks.ja.md` に追記

## Validation

- `uv lock --check`
- `uv sync --locked --group dev --group test --group security`
  - `passlib==1.7.4` が uninstall されることを確認
- `uv run --locked python -c "import importlib.util; print(importlib.util.find_spec('passlib'))"`
  - `None`
- bcrypt helper 簡易確認
  - `$2b$` hash 生成
  - 正しい password 検証成功
  - 誤った password 検証失敗
- 対象ユニットテスト
  - `34 passed`
- 非 DB component テスト
  - `204 passed, 1 skipped, 11 deselected`
- `uv run --locked pip-audit`
  - `pip 26.0.1 / CVE-2026-3219` のみ残存
  - `bcrypt` の新規検出なし
- `git diff --check`

## Container Validation

ローカル unified prod 構成で確認しました。

- `.\start-docker.ps1 unified-prod-build`
- `.\start-docker.ps1 unified-prod`

ブラウザ操作で確認:

- 通常 password login: 成功
- タスク管理操作: 成功
- 新規ユーザー登録 -> password login: 成功
- OIDC / SSO login: 成功
- SAML login: 成功

ログ確認で以下を確認:

- `Login successful`
- `User registered successfully`
- `SSO login successful`
- `SAML login successful`
- `/api/v1/auth/me`、`/api/v1/todos`、`/api/v1/todos` 更新系 request 成功

以下の DM-11 関連ログは確認されませんでした。

- `passlib`
- `error reading bcrypt version`
- `passlib/handlers/bcrypt.py`
- `Traceback`
- `Password verification failed`

## Notes

`bcrypt>=4.3.0,<5.0.0` とし、`5.0.0` は今回採用していません。`bcrypt 5.0.0` では 72 bytes 超過 password の扱いが変わるため、今回の passlib 脱却 PR では 4.x 系に留めています。

`InsecureKeyLengthWarning` は引き続きログに残っていますが、これは `JWT_SECRET` が HS256 推奨長 32 bytes 未満であることによる既知警告であり、password hashing backend 移行とは別件です。
