### PR TITLE
chore: address DM-09 bandit findings

### DIFF
--- a/components/koiki_ref_app/src/koiki_ref_app/api/v1/endpoints/saml_auth.py
+++ b/components/koiki_ref_app/src/koiki_ref_app/api/v1/endpoints/saml_auth.py
@@ -238,7 +238,6 @@ async def saml_login(
         return TokenWithRefresh(
             access_token=access_token,
             refresh_token=refresh_token,
-            token_type="bearer",
             expires_in=expires_in,
         )
 

--- a/components/koiki_ref_app/src/koiki_ref_app/api/v1/endpoints/sso_auth.py
+++ b/components/koiki_ref_app/src/koiki_ref_app/api/v1/endpoints/sso_auth.py
@@ -197,7 +197,6 @@ async def sso_login(
         return TokenWithRefresh(
             access_token=access_token,
             refresh_token=refresh_token,
-            token_type="bearer",
             expires_in=expires_in,
         )
 

--- a/components/libkoiki/src/libkoiki/api/v1/endpoints/auth_basic.py
+++ b/components/libkoiki/src/libkoiki/api/v1/endpoints/auth_basic.py
@@ -201,7 +201,6 @@ async def login_for_access_token(
     return TokenWithRefresh(
         access_token=access_token,
         refresh_token=refresh_token,
-        token_type="bearer",
         expires_in=expires_in,
     )
 

--- a/components/libkoiki/src/libkoiki/api/v1/endpoints/auth_token.py
+++ b/components/libkoiki/src/libkoiki/api/v1/endpoints/auth_token.py
@@ -68,7 +68,6 @@ async def refresh_token(
     return TokenWithRefresh(
         access_token=access_token,
         refresh_token=new_refresh_token or refresh_data.refresh_token,
-        token_type="bearer",
         expires_in=expires_in
     )
 

--- a/components/libkoiki/src/libkoiki/core/logging.py
+++ b/components/libkoiki/src/libkoiki/core/logging.py
@@ -418,12 +418,9 @@ def clear_request_context():
 
 def get_request_context() -> Dict[str, Any]:
     """現在のリクエストコンテキストを安全に取得する"""
-    try:
-        context = request_context.get()
-        if isinstance(context, dict):
-            return context.copy()
-    except Exception:
-        pass
+    context = request_context.get()
+    if isinstance(context, dict):
+        return context.copy()
     return {}
 
 # リクエスト情報をログに追加するプロセッサ
@@ -431,21 +428,18 @@ def add_request_info(logger, method_name, event_dict):
     """リクエスト情報をログに追加する安全なプロセッサ"""
     if not isinstance(event_dict, dict):
         return event_dict
-    try:
-        ctx = request_context.get()
-        if ctx:
-            # 辞書の浅いコピーをマージ（深いコピーではない）
-            for k, v in ctx.items():
-                event_dict[f"request.{k}"] = v
-    except Exception:
-        pass
+    ctx = request_context.get()
+    if isinstance(ctx, dict):
+        # 辞書の浅いコピーをマージ（深いコピーではない）
+        for k, v in ctx.items():
+            event_dict[f"request.{k}"] = v
     return event_dict
 
 # カスタムプロセッサ（すべて防御的コーディング）
 def add_timestamp(logger, method_name, event_dict):
     """タイムスタンプを追加する安全なプロセッサ"""
     import datetime
-    from zoneinfo import ZoneInfo
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
     if not isinstance(event_dict, dict):
         return event_dict
     try:
@@ -453,7 +447,7 @@ def add_timestamp(logger, method_name, event_dict):
         if settings.LOG_TIMEZONE != "UTC":
             try:
                 tz = ZoneInfo(settings.LOG_TIMEZONE)
-            except Exception:
+            except (ValueError, ZoneInfoNotFoundError):
                 pass  # Fallback to UTC on error
         
         event_dict["timestamp"] = datetime.datetime.now(tz).isoformat()

--- a/components/libkoiki/src/libkoiki/core/security_logger.py
+++ b/components/libkoiki/src/libkoiki/core/security_logger.py
@@ -20,20 +20,25 @@ SECURITY_EVENT_AUTHENTICATION_BLOCKED_LOCKOUT = (
 SECURITY_EVENT_AUTHENTICATION_SUCCEEDED_AFTER_RISK_CHECK = (
     "authentication_succeeded_after_risk_check"
 )
-SECURITY_EVENT_REFRESH_TOKEN_REJECTED = "refresh_token_rejected"
+# Security event names are log labels, not secrets.
+SECURITY_EVENT_REFRESH_TOKEN_REJECTED = "refresh_token_rejected"  # nosec B105
 SECURITY_EVENT_PASSWORD_RESET_REQUESTED_EXISTING_USER = (
-    "password_reset_requested_existing_user"
+    # Security event names are log labels, not secrets.
+    "password_reset_requested_existing_user"  # nosec B105
 )
-SECURITY_EVENT_PASSWORD_RESET_COMPLETED = "password_reset_completed"
+# Security event names are log labels, not secrets.
+SECURITY_EVENT_PASSWORD_RESET_COMPLETED = "password_reset_completed"  # nosec B105
 SECURITY_EVENT_PASSWORD_RESET_REJECTED_INVALID_TOKEN = (
-    "password_reset_rejected_invalid_token"
+    # Security event names are log labels, not secrets.
+    "password_reset_rejected_invalid_token"  # nosec B105
 )
 SECURITY_EVENT_SSO_LOGIN_FAILED = "sso_login_failed"
 SECURITY_EVENT_SSO_LOGIN_SUCCEEDED = "sso_login_succeeded"
 SECURITY_EVENT_SAML_LOGIN_FAILED = "saml_login_failed"
 SECURITY_EVENT_SAML_LOGIN_SUCCEEDED = "saml_login_succeeded"
 SECURITY_EVENT_TOKEN_REUSE_OR_INTEGRITY_VIOLATION_DETECTED = (
-    "token_reuse_or_integrity_violation_detected"
+    # Security event names are log labels, not secrets.
+    "token_reuse_or_integrity_violation_detected"  # nosec B105
 )
 SECURITY_EVENT_SUSPICIOUS_ACTIVITY_DETECTED = "suspicious_activity_detected"
 SECURITY_EVENT_RATE_LIMIT_EXCEEDED_SECURITY_SENSITIVE_ENDPOINT = (

--- a/docs/dev/deferred-maintenance-tasks.ja.md
+++ b/docs/dev/deferred-maintenance-tasks.ja.md
@@ -649,6 +649,8 @@ uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests 
 
 優先度: `P5`
 
+状態: `実装・ローカル検証済み`
+
 詳細実施計画:
 
 - `docs/dev/dm08-dm10-security-task-plan.ja.md`
@@ -669,6 +671,38 @@ uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests 
 - false positive は理由を明記して `# nosec` または設定除外を検討する
 - 実リスクがあるものはコード修正に回す
 
+### 実施結果
+
+実行日: 2026-05-04
+
+更新前の Bandit 結果:
+
+- `High`: 0
+- `Medium`: 0
+- `Low`: 12
+
+Low 検出の分類:
+
+- `B106 hardcoded_password_funcarg`: OAuth2 `token_type="bearer"` 4 件
+  - secret ではなく token type 定数
+  - `TokenWithRefresh` schema に `token_type = "bearer"` の default があるため、endpoint 側の明示指定を削除して解消した
+- `B105 hardcoded_password_string`: security event name 定数 5 件
+  - secret ではなく security log の event type label
+  - 対象行へ局所 `# nosec B105` を付与し、直前コメントで理由を記録した
+- `B110 try_except_pass`: logging fallback 3 件
+  - `request_context.get()` 周辺は broad `try/except/pass` を外し、`dict` 判定で安全に扱う形へ変更した
+  - timezone fallback は `Exception` ではなく `ValueError` / `ZoneInfoNotFoundError` に絞った
+
+更新後の Bandit 結果:
+
+- `High`: 0
+- `Medium`: 0
+- `Low`: 0
+- 局所 `# nosec B105`: 5 件
+
+広域除外や plugin 全体除外は行っていない。
+`# nosec` は security event name の false positive に限定した。
+
 ### 完了条件
 
 - Bandit の残件がレビュー可能な粒度に減る
@@ -681,6 +715,41 @@ uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests 
 $env:UV_CACHE_DIR='.uv-cache-codex'
 uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level medium
 ```
+
+実施済み結果:
+
+```text
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level low
+  No issues identified.
+  Low: 0
+  Medium: 0
+  High: 0
+  Total potential issues skipped due to specifically being disabled: 5
+
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/test_input_logging.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/services/test_saml_service.py
+  65 passed, 1 skipped
+
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/services/test_saml_service.py
+  55 passed
+
+uv run --locked pytest components/libkoiki/tests/unit/core/test_logging_sanitizer.py components/libkoiki/tests/unit/libkoiki/test_input_logging.py
+  38 passed, 1 skipped
+```
+
+既存の `AsyncMock` と transaction helper の組み合わせによる `RuntimeWarning` は残るが、DM-09 の Bandit false positive 整理による失敗ではない。
+
+コンテナ確認:
+
+```text
+unified prod container build / run: 成功
+ブラウザ password login: 成功
+ブラウザ OIDC SSO login: 成功
+ブラウザ SAML login: 成功
+タスク管理操作: 成功
+アプリコンテナログ点検: Traceback / ResponseValidationError / ValidationError / Internal Server Error / Invalid token response / Password verification failed なし
+```
+
+残る `InsecureKeyLengthWarning` は `JWT_SECRET` が HS256 推奨長 32 bytes 未満であることによる既知警告であり、DM-09 の Bandit false positive 整理とは別件として扱う。
 
 ## 11. `DM-10` SAML metadata XML parser hardening
 

--- a/docs/dev/dm08-dm10-security-task-plan.ja.md
+++ b/docs/dev/dm08-dm10-security-task-plan.ja.md
@@ -147,6 +147,69 @@ uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests 
 
 Bandit の検出結果を、コード修正すべき実リスクと false positive に分ける。
 
+### 実施結果
+
+実行日: 2026-05-04
+
+更新前:
+
+- `High`: 0
+- `Medium`: 0
+- `Low`: 12
+
+Low 12 件の内訳:
+
+- `B106`: OAuth2 `token_type="bearer"` 4 件
+  - secret ではなく token type 定数
+  - `TokenWithRefresh` schema の default で表現できるため、endpoint 側の明示指定を削除した
+- `B105`: security event name 定数 5 件
+  - secret ではなく security log の event type label
+  - 局所 `# nosec B105` と直前コメントで理由を記録した
+- `B110`: logging fallback の `try/except/pass` 3 件
+  - `request_context.get()` 周辺は broad exception handling を外し、`dict` 判定へ整理した
+  - timezone fallback は `ValueError` / `ZoneInfoNotFoundError` に例外型を絞った
+
+更新後:
+
+- `High`: 0
+- `Medium`: 0
+- `Low`: 0
+- 局所 `# nosec B105`: 5 件
+
+広域除外や Bandit plugin 全体除外は行っていない。
+`# nosec` は security event name の false positive に限定した。
+
+検証結果:
+
+```text
+uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level low
+  No issues identified.
+  Low: 0
+  Medium: 0
+  High: 0
+
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/services/test_saml_service.py
+  55 passed
+
+uv run --locked pytest components/libkoiki/tests/unit/core/test_logging_sanitizer.py components/libkoiki/tests/unit/libkoiki/test_input_logging.py
+  38 passed, 1 skipped
+```
+
+既存の `AsyncMock` と transaction helper の組み合わせによる `RuntimeWarning` は残るが、DM-09 の Bandit false positive 整理による失敗ではない。
+
+コンテナ確認:
+
+```text
+unified prod container build / run: 成功
+ブラウザ password login: 成功
+ブラウザ OIDC SSO login: 成功
+ブラウザ SAML login: 成功
+タスク管理操作: 成功
+アプリコンテナログ点検: Traceback / ResponseValidationError / ValidationError / Internal Server Error / Invalid token response / Password verification failed なし
+```
+
+残る `InsecureKeyLengthWarning` は `JWT_SECRET` が HS256 推奨長 32 bytes 未満であることによる既知警告であり、DM-09 の Bandit false positive 整理とは別件として扱う。
+
 ### 実施手順
 
 1. JSON と通常出力で現状を取得する。


### PR DESCRIPTION
## 概要

DM-09 として、Bandit 検出結果の分類、false positive 方針整理、必要最小限の修正を実施しました。

## 変更内容

- Bandit Low 12 件を分類しました。
  - `B106`: OAuth2 `token_type="bearer"` 4 件
  - `B105`: security event name 定数 5 件
  - `B110`: logging fallback の `try/except/pass` 3 件
- `token_type="bearer"` は `TokenWithRefresh` schema default に任せる形へ変更しました。
- security event name 定数は secret ではないため、理由コメント付きで局所 `# nosec B105` を付与しました。
- logging fallback は broad `except/pass` を減らし、実リスクになり得る exception handling を最小修正しました。
- DM-09 の実施結果と検証結果をドキュメントへ反映しました。

## 判断

- High / Medium の Bandit 検出は 0 件です。
- 広域除外や Bandit plugin 全体除外は行っていません。
- `# nosec` は security event name の false positive 5 件のみです。
- `B110` は抑制ではなくコード修正で対応しました。

## 検証

- `uv run --locked bandit -r app components/libkoiki/src components/koiki_ref_app/src --severity-level low`
  - `No issues identified.`
  - `Low: 0`
  - `Medium: 0`
  - `High: 0`

- `uv run --locked pytest components/libkoiki/tests/unit/libkoiki/services/test_auth_service.py components/libkoiki/tests/unit/libkoiki/services/test_auth_service_comprehensive.py components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/services/test_saml_service.py`
  - `55 passed`

- `uv run --locked pytest components/libkoiki/tests/unit/core/test_logging_sanitizer.py components/libkoiki/tests/unit/libkoiki/test_input_logging.py`
  - `38 passed, 1 skipped`

- `uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent_guidance components/koiki_ref_app/tests tests/integration/services -m "not db_integration"`
  - `218/255 tests collected, 37 deselected`

## コンテナ確認

- unified prod container build / run: 成功
- ブラウザ password login: 成功
- ブラウザ OIDC SSO login: 成功
- ブラウザ SAML login: 成功
- タスク管理操作: 成功
- アプリコンテナログ点検:
  - `Traceback` なし
  - `ResponseValidationError` なし
  - `ValidationError` なし
  - `Internal Server Error` なし
  - `Invalid token response` なし
  - `Password verification failed` なし

## 既知事項

- 既存の `AsyncMock` / transaction helper 由来の `RuntimeWarning` は残りますが、DM-09 変更による失敗ではありません。
- `InsecureKeyLengthWarning` は `JWT_SECRET` が HS256 推奨長 32 bytes 未満である既知警告であり、DM-09 とは別件です。
