### PR TITLE
docs: define API ownership boundary policy

### DIFF
--- a/docs/agent/boundaries.md
+++ b/docs/agent/boundaries.md
@@ -26,6 +26,16 @@ Place code in `components/koiki_ref_app/` when it is:
 - an application-level composition of existing framework capabilities
 - tied to current SSO, SAML, or business feature behavior for this project
 
+## API Ownership
+
+Framework APIs in `components/libkoiki/` must be reusable framework capabilities or explicitly documented starter/sample capabilities.
+
+Application APIs in `components/koiki_ref_app/` should own project-specific workflows, integrations, and UI-facing application behavior.
+
+Downstream or customer-specific APIs should start under `apps/` unless they are clearly reusable framework behavior or reference-app starter behavior.
+
+The current Todo API is treated as a `libkoiki` starter/sample capability. Do not use it as precedent for putting new business-specific APIs into `components/libkoiki/`.
+
 ## Decision Heuristic
 
 When deciding where a change belongs, ask:

--- a/docs/dev/deferred-maintenance-tasks.ja.md
+++ b/docs/dev/deferred-maintenance-tasks.ja.md
@@ -24,6 +24,8 @@
 | `DM-11` | P5 | security | password hashing backend を `passlib` から `bcrypt` 直利用へ移行する | 単独 |
 | `DM-12` | P4 | cleanup/docs | v0.7 新規参加者向けに legacy / compatibility 残骸を棚卸しする | 棚卸し単独、削除は別 PR |
 | `DM-13` | P4 | release/docs | v0.7.0 release preparation と version / release docs を整える | 単独 |
+| `DM-14` | P4 | architecture/docs | API ownership / sample feature boundary policy を整理する | 単独 |
+| `DM-15` | P4 | agent/docs | Agent guidance / Skills consistency を整理する | 単独 |
 
 ## 2. `DM-01` Settings.DATABASE_URL 組み立て復旧
 
@@ -1087,7 +1089,62 @@ uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent
 - 削除判断は棚卸し PR とは分け、別 PR で小さく扱う
 - セキュリティ残タスク `DM-09` と混ぜない
 
-## 14. `DM-13` v0.7.0 release preparation
+## 14. `DM-14` API ownership / sample feature boundary policy
+
+優先度: `P4`
+
+状態: `方針文書作成済み`
+
+方針文書:
+
+- `docs/dev/dm14-api-ownership-boundary-policy.ja.md`
+
+### 目的
+
+v0.7 以降の API 実装で、`components/libkoiki/`、`components/koiki_ref_app/`、`apps/` のどこに何を置くかを場当たりにしない。
+
+特に Todo タスク管理 API のように、サンプルとして有用だが業務 API にも見える機能について、framework 層に置く条件と reference app 層に置く条件を明確にする。
+
+### 判断経緯
+
+現行 Todo API は、model / schema / repository / service / endpoint が主に `components/libkoiki/` 側にあり、`koiki_ref_app` は `libkoiki` router を include して参照アプリとして利用している。
+
+これは「reference app 固有の業務機能」というより「libkoiki に含まれる framework sample / starter capability」として動作している。
+
+ただし、この位置づけを明文化しないと、今後の新規 business API も `libkoiki` に置いてよいと誤解される恐れがある。
+
+### 対象
+
+- `docs/dev/dm14-api-ownership-boundary-policy.ja.md`
+- `docs/agent/boundaries.md`
+- 必要に応じて `docs/agent/app.md` / `docs/agent/libkoiki.md`
+
+### 実施結果
+
+- API ownership policy を文書化した
+- `components/libkoiki/` に置ける API の条件を整理した
+- `components/koiki_ref_app/` に置く API の条件を整理した
+- `apps/` に置く API の条件を整理した
+- Todo API は当面 `libkoiki` の `framework sample / starter capability` として維持する方針を明記した
+- Todo のコード移動や router 構成変更は、このタスクでは行わない方針にした
+- `docs/agent/boundaries.md` に API ownership の短い判断ルールを追加した
+
+### 完了条件
+
+- API ownership policy が文書化されている
+- Todo API の現状位置づけが `framework sample / starter capability` として説明されている
+- 新規 business API を安易に `libkoiki` へ置かない方針が明記されている
+- Todo のコード移動や router 変更をこの PR で行わないことが明記されている
+- 後続判断候補が整理されている
+
+### 検証
+
+```powershell
+rg -n "todo|todos|Todo" components/libkoiki/src components/koiki_ref_app/src components/libkoiki/tests components/koiki_ref_app/tests docs/agent README.md -S
+rg --files components/libkoiki/src components/koiki_ref_app/src | rg "todo|router|dependencies|app_factory|asgi"
+```
+
+## 15. `DM-13` v0.7.0 release preparation
 
 優先度: `P4`
 
@@ -1145,7 +1202,51 @@ uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent
 
 必要に応じて、コンテナ build / run 後に health response の version 表示も確認する。
 
-## 15. 推奨実行順
+## 16. `DM-15` Agent guidance / Skills consistency review
+
+優先度: `P4`
+
+状態: `未着手`
+
+### 目的
+
+Codex、Claude Code、GitHub Copilot などの AI agent が、同じ repository boundary / API ownership / task routing を参照できるように、agent guidance と Skills 相当の導線を一貫して整理する。
+
+`DM-14` で API ownership / sample feature boundary policy を整理したため、その方針を agent-facing docs / instructions / skills へどう反映するかを、次タスクとして扱う。
+
+### 対象候補
+
+- `AGENTS.md`
+- `docs/agent/`
+- `docs/agent/skills/`
+- `.github/copilot-instructions.md`
+- `.github/instructions/*.instructions.md`
+- Claude Code 向けに残っている guidance / skills 相当の導線
+- `docs/dev/agent-skill-checklist.md`
+
+### 作業
+
+- `docs/agent/*` と `.github/*instructions*` の役割分担を確認する
+- Codex / Claude Code / GitHub Copilot が、`components/libkoiki/`、`components/koiki_ref_app/`、`apps/` の境界を同じように判断できるか確認する
+- `DM-14` の API ownership policy を agent-facing guidance へ反映する範囲を決める
+- Agent Skills の trigger / expected usage と、現行 repository boundary の整合を確認する
+- 重複文書や古い path 参照があれば、現行正本と履歴資料のどちらかに分類する
+- 大きな Skill 実体変更やファイル移動が必要な場合は、別 PR に分ける
+
+### 完了条件
+
+- agent guidance の正本と補助資料の役割が説明できる
+- Codex / Claude Code / GitHub Copilot で API ownership と作業境界の判断が大きくずれない
+- `DM-14` の方針が agent-facing guidance へ反映されるか、後続対象として明確化されている
+- v0.7.0 release preparation 前に、AI agent 向け導線の一貫性が確認されている
+
+### 検証
+
+```powershell
+rg -n "components/libkoiki|components/koiki_ref_app|apps/|app/|Todo|API ownership|Skills|Copilot|Claude|Codex" AGENTS.md docs/agent .github docs/dev/agent-skill-checklist.md -S
+```
+
+## 17. 推奨実行順
 
 1. `DM-01`
 2. `DM-02`
@@ -1159,17 +1260,20 @@ uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent
 10. `DM-11`
 11. `DM-09`
 12. `DM-12`
-13. `DM-13`
-14. `DM-12-C`
+13. `DM-14`
+14. `DM-15`
+15. `DM-13`
+16. `DM-12-C`
 
 `DM-01` と `DM-02` は、他タスクの前に小さく処理する。
 `DM-03` から `DM-05` は Pydantic v2 互換性としてまとめて扱えるが、差分が大きくなる場合は schema / service / logging に分ける。
 `DM-08` は runtime 依存の脆弱性監査結果を優先して先行対応済み。
 `DM-08` 後は `DM-10`、`DM-11`、`DM-09` の順に進める。
 `DM-12` は削除系・導線整理系のため、`DM-09` のセキュリティ整理後に棚卸しから開始する。
-`DM-12-B` 完了後は、`app.main:app` 互換終了判断である `DM-12-C` へ進む前に、`DM-13` で v0.7.0 release preparation を整理する。
+`DM-12-B` 完了後は、`DM-14` で API ownership / sample feature boundary policy を整理し、続けて `DM-15` で agent guidance / Skills consistency を確認してから `DM-13` の v0.7.0 release preparation へ進む。
+`DM-12-C` の `app.main:app` 互換終了判断は、`DM-13` 後に扱う。
 
-## 16. 共通 NG 条件
+## 18. 共通 NG 条件
 
 - import error
 - lock mismatch

--- a/docs/dev/dm12-legacy-compatibility-inventory.ja.md
+++ b/docs/dev/dm12-legacy-compatibility-inventory.ja.md
@@ -296,7 +296,9 @@ uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent
 
 着手順序:
 
-- `DM-12-B` 完了後、先に `DM-13` として v0.7.0 release preparation を実施する
+- `DM-12-B` 完了後、先に `DM-14` として API ownership / sample feature boundary policy を整理する
+- `DM-14` 後、`DM-15` として Agent guidance / Skills consistency を整理する
+- `DM-15` 後、`DM-13` として v0.7.0 release preparation を実施する
 - `DM-13` で version metadata と release docs を整理してから、`app.main:app` 互換終了判断へ進む
 - release / versioning と compatibility wrapper の削除判断を同一 PR に混ぜない
 
@@ -365,8 +367,10 @@ KOIKI Framework
 
 この棚卸しにより、DM-12-A / DM-12-B 実施後に残る後続 PR 候補は次である。
 
-1. `DM-13`: v0.7.0 release preparation
-2. `DM-12-C`: `app.main:app` 互換終了判断
+1. `DM-14`: API ownership / sample feature boundary policy
+2. `DM-15`: Agent guidance / Skills consistency review
+3. `DM-13`: v0.7.0 release preparation
+4. `DM-12-C`: `app.main:app` 互換終了判断
 
 root `libkoiki/setup.py` は、現行 dependency と矛盾し、`passlib[bcrypt]` を含むため、DM-12-A で先行削除した。
 現行 docs の旧導線整理は、DM-12-B で履歴資料を残しつつ正規導線注記を追加した。

--- a/docs/dev/dm14-api-ownership-boundary-policy.ja.md
+++ b/docs/dev/dm14-api-ownership-boundary-policy.ja.md
@@ -1,0 +1,177 @@
+# DM-14 API ownership / sample feature boundary policy
+
+作成日: 2026-05-04
+
+対象タスク:
+
+- `docs/dev/deferred-maintenance-tasks.ja.md` の `DM-14`
+
+## 1. 目的
+
+v0.7 以降の API 実装で、`components/libkoiki/`、`components/koiki_ref_app/`、`apps/` のどこに何を置くかを場当たりにしない。
+
+特に Todo タスク管理 API のように、サンプルとして有用だが業務 API にも見える機能について、framework 層に置く条件と reference app 層に置く条件を明確にする。
+
+この PR では、コード移動や router 構成変更は行わない。
+まず所有境界と判断基準を文書化し、Todo API の現在位置づけと後続判断を明確にする。
+
+## 2. 現行確認
+
+Todo タスク管理 API は、現状では主に `components/libkoiki/` 側に実装されている。
+
+代表的な配置:
+
+- `components/libkoiki/src/libkoiki/models/todo.py`
+- `components/libkoiki/src/libkoiki/schemas/todo.py`
+- `components/libkoiki/src/libkoiki/repositories/todo_repository.py`
+- `components/libkoiki/src/libkoiki/services/todo_service.py`
+- `components/libkoiki/src/libkoiki/api/v1/endpoints/todos.py`
+- `components/libkoiki/src/libkoiki/api/v1/router.py`
+
+`components/koiki_ref_app/` 側では、reference app の `app_factory.py` が `libkoiki` の API router を include することで Todo API を利用している。
+
+また、`components/koiki_ref_app/src/koiki_ref_app/models/__init__.py` では `TodoModel` を re-export している。
+
+このため、Todo は現在「reference app 固有の業務機能」ではなく、「libkoiki に含まれる framework sample / starter capability」として動作している。
+
+## 3. リスク
+
+現行構成のままでも動作上の問題はないが、次の混乱リスクがある。
+
+- Todo が `libkoiki` にあるため、業務 API も framework 側へ置いてよいように見える
+- `libkoiki.api.v1.router` が `/todos` を標準 include しており、framework 利用アプリへ sample API が常時入る構造に見える
+- `koiki_ref_app` 側には Todo の業務実装がほぼないため、reference app feature なのか framework sample なのか境界が曖昧
+- 今後 `apps/` や案件固有 API を足す際、配置判断がぶれやすい
+
+## 4. API ownership policy
+
+### 4.1 `components/libkoiki/` に置く API
+
+`components/libkoiki/` に置ける API は、複数アプリで再利用する framework capability に限る。
+
+該当例:
+
+- authentication / token / password / user / RBAC
+- security monitoring / audit / rate limit
+- common persistence / schema / repository / service patterns
+- starter application が共通で持ってよい最小 sample API
+
+判断条件:
+
+- 特定業務ドメインに依存しない
+- 複数アプリで同じ contract として再利用できる
+- application-specific な workflow や外部 integration 判断を含まない
+- framework 利用者に exposed API として説明できる
+
+### 4.2 `components/koiki_ref_app/` に置く API
+
+`components/koiki_ref_app/` に置く API は、reference app の business behavior または application-level composition である。
+
+該当例:
+
+- SSO / SAML の reference app integration
+- business clock など current reference app 固有の workflow
+- framework capability を組み合わせた app-level API
+- reference app の UI / frontend contract に強く結びつく API
+
+判断条件:
+
+- 現在の reference app 固有の業務判断を含む
+- integration や deployment 前提が current project に依存する
+- 他アプリへそのまま再利用するには抽象化が足りない
+- framework 側へ置くと project-specific assumption が混ざる
+
+### 4.3 `apps/` に置く API
+
+`apps/` は downstream 案件固有 backend API 実装の予約領域である。
+
+該当例:
+
+- 特定顧客・案件・業務に閉じた API
+- reusable framework に戻す前の業務拡張
+- reference app の標準機能として一般化しない API
+
+判断条件:
+
+- framework / reference app の正本へすぐ戻すべきではない
+- 案件固有の table、workflow、外部 integration を含む
+- starter として全利用者へ提供するには narrow すぎる
+
+## 5. Todo API の暫定方針
+
+Todo API は、当面 `libkoiki` の `framework sample / starter capability` として維持する。
+
+理由:
+
+- v0.6 系から Todo sample として存在し、認証済みユーザーと owner scoped CRUD の最小例として機能している
+- frontend のタスク管理 sample と結びつき、v0.7 の動作確認にも利用されている
+- いきなり `koiki_ref_app` 側へ移すと router、model relation、tests、frontend contract、migration の確認範囲が広がる
+
+ただし、今後の新規業務 API を Todo と同じ理由で `libkoiki` に置いてよいわけではない。
+
+Todo は `sample / starter capability` であり、business-specific API の配置先例ではない。
+
+## 6. 後続判断候補
+
+Todo API の最終形は、v0.7.0 後に次のいずれかで判断する。
+
+### Option A: `libkoiki` の sample router として明示維持
+
+- `libkoiki` 側に残す
+- `ToDos Sample` として明確に説明する
+- framework 利用者が sample router を include / exclude できる構成を検討する
+
+### Option B: `koiki_ref_app` 側へ移す
+
+- Todo を reference app の sample feature として扱う
+- model / schema / repository / service / endpoint を `koiki_ref_app` 側へ移す
+- `libkoiki` には generic CRUD / ownership pattern だけを残すか判断する
+
+### Option C: `libkoiki` に generic base capability を残し、Todo concrete を app 側へ置く
+
+- reusable ownership / CRUD pattern を `libkoiki` に残す
+- Todo concrete model / endpoint は `koiki_ref_app` に置く
+- 最も整理された形だが、抽象化が増えるため v0.7.0 前には行わない
+
+## 7. 完了条件
+
+- API ownership policy が文書化されている
+- Todo API の現状位置づけが `framework sample / starter capability` として説明されている
+- 新規 business API を安易に `libkoiki` へ置かない方針が明記されている
+- Todo のコード移動や router 変更をこの PR で行わないことが明記されている
+- 後続判断候補が整理されている
+
+## 8. 確認コマンド
+
+```powershell
+rg -n "todo|todos|Todo" components/libkoiki/src components/koiki_ref_app/src components/libkoiki/tests components/koiki_ref_app/tests docs/agent README.md -S
+rg --files components/libkoiki/src components/koiki_ref_app/src | rg "todo|router|dependencies|app_factory|asgi"
+```
+
+## 9. 結論
+
+DM-14 では、Todo API の配置をすぐ変更しない。
+
+まず、v0.7 以降の API ownership policy を明文化し、Todo を `libkoiki` の sample / starter capability として暫定維持する。
+
+実際の Todo 移動、optional router 化、または generic base capability 化は、v0.7.0 release preparation 後の別 PR で扱う。
+
+## 10. 次タスク
+
+DM-14 の次は `DM-15: Agent guidance / Skills consistency review` とする。
+
+理由:
+
+- `DM-14` で整理した API ownership policy は、人間の開発者だけでなく AI agent の作業判断にも影響する
+- Codex、Claude Code、GitHub Copilot が `components/libkoiki/`、`components/koiki_ref_app/`、`apps/` の境界を同じように判断できる必要がある
+- v0.7.0 release preparation の前に agent-facing guidance の一貫性を確認しておくと、README / release note / agent docs の説明がぶれにくい
+
+推奨順:
+
+1. `DM-14`: API ownership / sample feature boundary policy
+2. `DM-15`: Agent guidance / Skills consistency review
+3. `DM-13`: v0.7.0 release preparation
+4. `DM-12-C`: `app.main:app` 互換終了判断
+
+DM-15 では、`AGENTS.md`、`docs/agent/`、`docs/agent/skills/`、`.github/copilot-instructions.md`、`.github/instructions/*.instructions.md`、Claude Code 向け guidance を横断確認する。
+大きな Skill 実体変更やファイル移動が必要な場合は、DM-15 内でさらに後続 PR へ分ける。


### PR DESCRIPTION
## 概要

DM-14 として、v0.7 以降の API 実装における ownership / 配置境界の方針を整理しました。

特に Todo API は現在 `components/libkoiki/` 側に実装されていますが、これは business API 配置の前例ではなく、`framework sample / starter capability` として暫定維持する方針を明記しています。

## 変更内容

- `docs/dev/dm14-api-ownership-boundary-policy.ja.md` を新規作成
  - `components/libkoiki/` に置く API の条件を整理
  - `components/koiki_ref_app/` に置く API の条件を整理
  - `apps/` に置く API の条件を整理
  - Todo API の現状位置づけを `framework sample / starter capability` として明記
  - Todo の移動 / optional router 化 / generic base 化は後続判断と整理

- `docs/agent/boundaries.md` を更新
  - API ownership の短い判断ルールを追加
  - Todo API を business-specific API 配置の前例にしないことを明記

- `docs/dev/deferred-maintenance-tasks.ja.md` を更新
  - `DM-14` をタスク一覧へ追加
  - `DM-15: Agent guidance / Skills consistency review` を次タスクとして追加
  - 推奨順を `DM-14 → DM-15 → DM-13 → DM-12-C` に整理

- `docs/dev/dm12-legacy-compatibility-inventory.ja.md` を更新
  - DM-12-C 前の後続順序に DM-14 / DM-15 / DM-13 を反映

## 判断理由

現在の Todo API は `libkoiki` に配置されており、認証済みユーザーの owner scoped CRUD sample として有用です。

一方で、この状態を明文化しないと、今後の business-specific API も `libkoiki` に置いてよいと誤解されるリスクがあります。

そのため、今回の PR ではコード移動や router 構成変更は行わず、まず API ownership policy を明文化することに留めています。

## 後続

推奨順は以下です。

1. DM-15: Agent guidance / Skills consistency review
2. DM-13: v0.7.0 release preparation
3. DM-12-C: `app.main:app` 互換終了判断

Todo API の移動、optional sample router 化、generic base capability 化は v0.7.0 release preparation 後の別 PR で判断します。

## 検証

- `git diff --check`

docs のみの変更のため、pytest は未実行です。
