### PR TITLE
Topic/dm13 v070 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 これは、Python (FastAPI) を用いたエンタープライズ向けWebアプリケーション構築のための、堅牢な基盤フレームワーク「KOIKI-FW」をベースにしたプロジェクトテンプレートです。
 
-現在は `v0.7` に向けた再編作業中で、バックエンドは `components/libkoiki` と `components/koiki_ref_app` を中心とした構成へ移行しています。
+現在は `v0.7.0` として、バックエンドを `components/libkoiki` と `components/koiki_ref_app` を中心とした構成へ整理しています。
 
-詳細は `docs/design_kkfw_0.6.0.md` と `docs/dev/` 配下の再編計画を参照してください。
+詳細は `docs/design_kkfw_0.7.0.md` と `docs/dev/` 配下の保守タスク記録を参照してください。
 
 ## 特徴
 
@@ -13,8 +13,8 @@
 *   **非同期処理**: 高パフォーマンスな非同期処理。
 *   **型安全性**: Pydantic と型ヒントによる開発効率と安全性の向上。
 *   **テスト容易性**: 依存性注入による容易なテスト実装。
-*   **🆕 v0.6.0 強化されたセキュリティ**: JWT認証, リフレッシュトークン, パスワードリセット, ログイン試行制限, RBAC, レートリミット等。
-*   **🆕 v0.6.0 認証系API**: modular認証システム（基本認証、パスワード管理、トークン管理）。
+*   **v0.7.0 構成整理**: reusable framework (`components/libkoiki`) と reference application (`components/koiki_ref_app`) の責務を明確化。
+*   **認証・セキュリティ基盤**: JWT認証, リフレッシュトークン, パスワードリセット, ログイン試行制限, RBAC, レートリミット等。
 *   **監視・ロギング**: 構造化ログ, 監査ログ, Prometheus連携。
 *   **継続的インテグレーション**: GitHub Actionsによる自動テスト、コード品質チェックの導入。
 
@@ -133,7 +133,7 @@ GitHub Actionsによる自動テストパイプラインが設定されており
 - root `app/` は互換導線を維持するための wrapper です。
 - `apps/` は downstream の案件固有コードのための予約領域です。
 
-詳細な構成と機能説明は `docs/design_kkfw_0.6.0.md` を参照してください。
+詳細な構成と機能説明は `docs/design_kkfw_0.7.0.md` を参照してください。
 
 ## 🔒 Fork・利用に関するご案内
 

--- a/components/koiki_ref_app/pyproject.toml
+++ b/components/koiki_ref_app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koiki_ref_app"
-version = "0.6.1"
+version = "0.7.0"
 description = "Reference application built with KOIKI Framework."
 authors = [{ name = "KOIKI Team" }]
 license = {text = "MIT"}

--- a/components/koiki_ref_app/src/koiki_ref_app/app_factory.py
+++ b/components/koiki_ref_app/src/koiki_ref_app/app_factory.py
@@ -248,7 +248,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title=settings.APP_NAME,
         debug=settings.DEBUG,
-        version="0.6.1",
+        version="0.7.0",
         openapi_url="/openapi.json" if settings.APP_ENV != "production" else None,
         docs_url="/docs" if settings.APP_ENV != "production" else None,
         redoc_url="/redoc" if settings.APP_ENV != "production" else None,
@@ -293,7 +293,7 @@ def create_app() -> FastAPI:
         return {
             "status": "healthy",
             "service": "koiki-framework",
-            "version": "0.6.1",
+            "version": "0.7.0",
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -303,7 +303,7 @@ def create_app() -> FastAPI:
         logger.debug("Root endpoint called.")
         return {
             "service": "KOIKI Framework API",
-            "version": "0.6.1",
+            "version": "0.7.0",
             "docs": "/docs",
             "health": "/health",
         }

--- a/components/libkoiki/pyproject.toml
+++ b/components/libkoiki/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libkoiki"
-version = "0.6.1"
+version = "0.7.0"
 description = "Enterprise-grade FastAPI application framework."
 readme = "README.md"
 authors = [{ name = "KOIKI Team" }]

--- a/components/libkoiki/src/libkoiki/__init__.py
+++ b/components/libkoiki/src/libkoiki/__init__.py
@@ -5,4 +5,4 @@ This package provides enterprise features for FastAPI applications
 including security, logging, error handling, and more.
 """
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/docs/agent/skills/koiki-app-feature-work/references/app-extension-patterns.md
+++ b/docs/agent/skills/koiki-app-feature-work/references/app-extension-patterns.md
@@ -13,7 +13,7 @@ Use this reference when the `koiki-app-feature-work` skill needs a compact remin
 
 Primary source material comes from:
 
-- `docs/design_kkfw_0.6.0.md` sections on application implementation examples
+- `docs/design_kkfw_0.7.0.md` sections on reference application implementation and API ownership
 - current `components/koiki_ref_app/` implementation
 - shared agent docs in `docs/agent/`
 

--- a/docs/agent/skills/koiki-auth-security/references/auth-security-reference.md
+++ b/docs/agent/skills/koiki-auth-security/references/auth-security-reference.md
@@ -13,7 +13,7 @@ Use this reference when the `koiki-auth-security` skill needs a compact reminder
 
 Primary source material comes from:
 
-- `docs/design_kkfw_0.6.0.md` sections on auth, security, logging, monitoring, and RBAC
+- `docs/design_kkfw_0.7.0.md` sections on auth, security, logging, monitoring, and RBAC
 - current auth, SSO, and SAML implementation under `components/libkoiki/` and `components/koiki_ref_app/`
 - shared agent docs in `docs/agent/`
 

--- a/docs/agent/skills/koiki-libkoiki-feature-work/references/framework-patterns.md
+++ b/docs/agent/skills/koiki-libkoiki-feature-work/references/framework-patterns.md
@@ -13,7 +13,7 @@ Use this reference when the `koiki-libkoiki-feature-work` skill needs a compact 
 
 Primary source material comes from:
 
-- `docs/design_kkfw_0.6.0.md` sections on config, DI, models, schemas, repositories, and services
+- `docs/design_kkfw_0.7.0.md` sections on reusable framework implementation and API ownership
 - current `components/libkoiki/` implementation
 - shared agent docs in `docs/agent/`
 

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1,3 +1,13 @@
 # API Specification
 
-FastAPI による API の仕様を記載します。
+KOIKI-FW v0.7.0 の API ownership と実装配置は `docs/design_kkfw_0.7.0.md` を参照してください。
+
+現行の API 実装場所:
+
+- framework API: `components/libkoiki/src/libkoiki/api/`
+- reference app API: `components/koiki_ref_app/src/koiki_ref_app/api/`
+- downstream customer-specific API: `apps/`
+
+FastAPI の OpenAPI schema は development 環境で `koiki_ref_app.asgi:app` を起動したうえで `/openapi.json` から確認します。Production では docs / redoc / openapi endpoint は無効化されます。
+
+Todo API は `components/libkoiki/` の framework sample / starter capability として維持されています。新規 business API を `components/libkoiki/` に置く前例として扱わないでください。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,12 @@
 # Architecture
 
-本プロジェクトのアーキテクチャ概要を記述します。
+KOIKI-FW の現行アーキテクチャは `docs/design_kkfw_0.7.0.md` を正規の開発者向け設計文書として参照してください。
+
+短い作業境界の確認には、次の shared agent docs も参照します。
+
+- `docs/agent/architecture.md`
+- `docs/agent/boundaries.md`
+- `docs/agent/app.md`
+- `docs/agent/libkoiki.md`
+
+履歴資料として `docs/design_kkfw_0.6.0.md` も残していますが、v0.7.0 の実装場所や起動導線を判断するときは現行実装と `docs/design_kkfw_0.7.0.md` を優先します。

--- a/docs/design_kkfw_0.7.0.md
+++ b/docs/design_kkfw_0.7.0.md
@@ -1,0 +1,323 @@
+# KOIKI-FW v0.7.0
+
+## 1. 目的
+
+本ドキュメントは、KOIKI-FW v0.7.0 の開発者向けアーキテクチャガイドです。
+
+v0.7.0 では、v0.6 系で拡張された認証・監査・Todo sample 基盤を維持しつつ、バックエンドを再利用可能な framework layer と reference application layer へ分離しました。
+
+開発者は、新規実装時に本ドキュメントと `docs/agent/` 配下の shared guidance を参照し、実装場所、API ownership、テスト範囲を判断してください。
+
+## 2. v0.7.0 の位置づけ
+
+v0.7.0 は、ディレクトリ再編と ownership 整理を反映した release preparation 版です。
+
+主な焦点:
+
+- `components/libkoiki/` を reusable backend framework として整理
+- `components/koiki_ref_app/` を reference application / backend starter として整理
+- root `app/` を legacy import / entrypoint 互換 wrapper として限定
+- `apps/` を downstream / customer-specific backend API の予約領域として明確化
+- Todo API を `libkoiki` の framework sample / starter capability として暫定維持
+- `uv` / component package / current test layout を現行開発導線として整理
+- Agent Skills / Copilot / Claude wrappers が同じ API ownership 判断を参照できるよう整備
+
+## 3. 正規ディレクトリ構成
+
+```text
+project-root/
+├── app/                              # compatibility wrapper for legacy app.main:app imports
+├── apps/                             # downstream/customer-specific backend API area
+├── components/
+│   ├── libkoiki/
+│   │   ├── src/libkoiki/             # reusable framework implementation
+│   │   └── tests/                    # framework-owned tests
+│   └── koiki_ref_app/
+│       ├── src/koiki_ref_app/        # reference app / backend starter
+│       ├── alembic/                  # reference-app-owned migrations
+│       └── tests/                    # reference-app-owned tests
+├── frontend/                         # starter frontend
+├── tests/                            # cross-cutting, e2e, integration, agent guidance tests
+├── docs/                             # developer, release, and historical documentation
+├── scripts/                          # local validation and development helpers
+└── ops/                              # operational and security support assets
+```
+
+### 3.1 `components/libkoiki/`
+
+`components/libkoiki/` は reusable backend framework layer です。
+
+ここに置くもの:
+
+- shared auth / token / password / user / RBAC behavior
+- shared config / middleware / logging / transaction behavior
+- reusable persistence, schema, repository, service patterns
+- reusable API contracts
+- explicitly documented starter/sample API behavior
+
+ここに置かないもの:
+
+- project-specific business rules
+- customer-specific workflow
+- reference app の UI contract に閉じた API
+- downstream 案件の外部連携や専用 table
+
+### 3.2 `components/koiki_ref_app/`
+
+`components/koiki_ref_app/` は reference application backend layer です。
+
+ここに置くもの:
+
+- reference app 固有の business behavior
+- app-level composition of `components/libkoiki/`
+- SSO / SAML など current reference app の integration
+- frontend と連携する application-level API contract
+- reference app / backend starter として一般化できる実装
+
+ここに置かないもの:
+
+- reusable framework behavior の重複実装
+- downstream customer-specific API
+- root `app/` compatibility wrapper の実装追加
+
+### 3.3 root `app/`
+
+root `app/` は compatibility wrapper です。
+
+現時点では `app.main:app` 互換を維持しますが、実装の正本ではありません。新規実装は `components/libkoiki/` または `components/koiki_ref_app/` に置きます。
+
+`app.main:app` の互換終了判断は、v0.7.0 release preparation 後の `DM-12-C` で扱います。
+
+### 3.4 `apps/`
+
+`apps/` は downstream / customer-specific backend API の予約領域です。
+
+ここに置く候補:
+
+- 特定顧客・案件固有の API
+- current reference app へ一般化しない workflow
+- reusable framework に戻す前の業務拡張
+- project-specific frontend/backend extension
+
+現時点では workspace package としては扱わず、配置方針のみを明確化しています。
+
+### 3.5 `frontend/`
+
+`frontend/` は root 配置の starter frontend です。
+
+v0.7.0 時点では reusable Python framework package には含めません。backend API contract、auth flow、Todo sample の UI 動作確認と組み合わせて reference app の利用例を提供します。
+
+## 4. Layered Architecture
+
+backend 実装では、原則として次の flow を守ります。
+
+```text
+API endpoint
+  -> Service
+    -> Repository
+      -> Model / DB session
+  -> Schema
+  -> Core / Infrastructure
+```
+
+責務:
+
+- API: request validation, dependency wiring, response shaping
+- Service: use-case orchestration, business rules, transaction boundary
+- Repository: persistence and query behavior
+- Model: DB table and relationship definition
+- Schema: validated input/output contract
+- Core: config, auth, middleware, logging, DB session, security utilities
+
+下位 layer から上位 layer へ依存させないことを基本とします。
+
+## 5. API Ownership Policy
+
+API の配置は次の基準で判断します。
+
+| API type | Primary location | 判断基準 |
+| --- | --- | --- |
+| reusable framework API | `components/libkoiki/` | 複数 application で同じ contract として使える |
+| reference app API | `components/koiki_ref_app/` | current reference app の workflow / integration / UI contract に属する |
+| downstream customer API | `apps/` | 特定顧客・案件・業務に閉じる |
+| compatibility API | root `app/` | legacy import / entrypoint 互換のみ |
+
+判断が曖昧な場合:
+
+1. その API は他 application でも必要か
+2. business rule を含むか
+3. `libkoiki` に置くと project-specific assumption が混ざるか
+4. app layer が framework capability を compose するだけで解けるか
+
+迷う場合は、まず `components/koiki_ref_app/` または `apps/` 側から始め、reusable abstraction が明確になってから `components/libkoiki/` へ戻します。
+
+## 6. Todo API の扱い
+
+Todo API は、v0.7.0 時点では `components/libkoiki/` の framework sample / starter capability として維持します。
+
+理由:
+
+- authenticated owner-scoped CRUD の最小例として機能している
+- frontend の Todo sample と結びつき、runtime smoke に使える
+- v0.6 系からの migration continuity を保つ
+- v0.7.0 前に app layer へ移すと router, model, migration, frontend contract の確認範囲が広がる
+
+重要:
+
+- Todo が `libkoiki` にあることは、新規 business API を `libkoiki` に置く前例ではありません。
+- 業務固有 rule を Todo に追加する場合は、reference app または downstream `apps/` の ownership を再判断します。
+- Todo の optional router 化、app layer 移動、generic base capability 化は v0.7.0 後の別タスクで扱います。
+
+## 7. Application Startup
+
+標準 ASGI entrypoint:
+
+```text
+koiki_ref_app.asgi:app
+```
+
+compatibility entrypoint:
+
+```text
+app.main:app
+```
+
+Docker / compose / local dev script は `koiki_ref_app.asgi:app` を標準導線として扱います。`app.main:app` は legacy compatibility のために残します。
+
+FastAPI metadata:
+
+- application version: `0.7.0`
+- `/health` response version: `0.7.0`
+- `/` service info version: `0.7.0`
+
+Production では OpenAPI docs / ReDoc は無効化されます。
+
+## 8. Auth / Security / SSO / SAML
+
+認証・認可の reusable behavior は `components/libkoiki/` が所有します。
+
+主な framework scope:
+
+- password hashing
+- JWT token creation / verification
+- refresh token handling
+- user and RBAC foundation
+- login security and audit event support
+- rate limiting and security middleware
+
+reference app scope:
+
+- SSO / SAML integration
+- SAML auth flow state
+- current project の IdP / deployment 前提
+- app-level logging and frontend flow composition
+
+security-sensitive change では unit test のみで済ませず、request / token / permission / redirect / session の integration 観点を含めます。
+
+## 9. Database / Migration
+
+v0.7.0 の Alembic 正規導線:
+
+```powershell
+uv run --locked alembic -c components/koiki_ref_app/alembic.ini current
+uv run --locked alembic -c components/koiki_ref_app/alembic.ini heads
+```
+
+migration ownership:
+
+- reference app DB schema は `components/koiki_ref_app/alembic/`
+- local host 実行では DB host に `localhost` を使う
+- Docker 内実行では DB host に `db` を使う
+
+DB table 作成は Alembic migrations で管理します。runtime startup は migration 済み schema を前提に DB connection を検証します。
+
+## 10. Testing Strategy
+
+テスト配置:
+
+- framework behavior: `components/libkoiki/tests/`
+- reference app behavior: `components/koiki_ref_app/tests/`
+- cross-cutting / integration / e2e / agent guidance: root `tests/`
+
+基本コマンド:
+
+```powershell
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+uv run --locked pytest tests/unit/agent_guidance
+uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent_guidance components/koiki_ref_app/tests tests/integration/services -m "not db_integration"
+```
+
+DB integration は必要なタスクでのみ明示的に実行します。
+
+Codex などの agent 環境では、`DEBUG=release` が混入する場合があります。repository validation では `DEBUG=True` または `DEBUG=False` を明示します。
+
+## 11. Agent Guidance
+
+v0.7.0 では agent-facing guidance も repository boundary と API ownership に追随しています。
+
+正本:
+
+- `AGENTS.md`
+- `docs/agent/`
+- `docs/agent/skills/`
+
+adapter / integration:
+
+- `.claude/skills/`
+- `.github/copilot-instructions.md`
+- `.github/instructions/*.instructions.md`
+- `tests/unit/agent_guidance/prompt_cases.yaml`
+- `docs/dev/agent-skill-checklist.md`
+
+repository-side contract test:
+
+```powershell
+uv run --locked pytest tests/unit/agent_guidance
+```
+
+実 runtime の skill selection は repository-side test だけでは証明できないため、必要に応じて `agent-skill-results.json` をローカル記録として使います。
+
+## 12. Release / Compatibility Notes
+
+v0.7.0 で履歴資料として残すもの:
+
+- `docs/design_kkfw_0.6.0.md`
+- `docs/releases/KOIKI-FW_0.6.0.md`
+- `docs/releases/KOIKI-FW_0.6.1.md`
+- `docs/dev/v0.7-*`
+- `docs/dev/v0.7-task-instructions/`
+
+現行作業で優先するもの:
+
+- `docs/design_kkfw_0.7.0.md`
+- `docs/agent/`
+- `docs/dev/deferred-maintenance-tasks.ja.md`
+- component package source under `components/`
+
+`app.main:app` 互換終了判断は v0.7.0 release preparation 後に別タスクとして扱います。
+
+## 13. Developer Checklist
+
+新規 backend change の前に確認すること:
+
+1. 実装場所は `components/libkoiki/`, `components/koiki_ref_app/`, `apps/` のどれか
+2. Todo sample を business API 配置の前例として扱っていないか
+3. layer flow を守っているか
+4. auth / SSO / SAML / RBAC / audit に触れるか
+5. migration が必要か
+6. frontend contract が変わるか
+7. test scope は unit / integration / e2e のどれが必要か
+8. docs / agent guidance の更新が必要か
+
+## 14. 関連文書
+
+- `docs/agent/boundaries.md`
+- `docs/agent/architecture.md`
+- `docs/agent/app.md`
+- `docs/agent/libkoiki.md`
+- `docs/agent/testing.md`
+- `docs/agent/auth-security.md`
+- `docs/dev/dm12-legacy-compatibility-inventory.ja.md`
+- `docs/dev/dm14-api-ownership-boundary-policy.ja.md`
+- `docs/dev/dm15-agent-guidance-skills-consistency.ja.md`
+- `docs/releases/KOIKI-FW_0.7.0.md`

--- a/docs/dev/deferred-maintenance-tasks.ja.md
+++ b/docs/dev/deferred-maintenance-tasks.ja.md
@@ -1148,11 +1148,12 @@ rg --files components/libkoiki/src components/koiki_ref_app/src | rg "todo|route
 
 優先度: `P4`
 
-状態: `未着手`
+状態: `実施中 / DM-13-A〜DM-13-D 対応中`
 
 計画文書:
 
-- `docs/dev/dm15-agent-guidance-skills-consistency.ja.md`
+- `docs/releases/KOIKI-FW_0.7.0.md`
+- `docs/design_kkfw_0.7.0.md`
 
 ### 目的
 
@@ -1181,12 +1182,40 @@ DM-12-B の docs 整理中に、現行コードや release docs に `0.6.1` / `v
 
 ### 作業
 
+#### DM-13-A: version metadata / FastAPI version / release note 骨子
+
 - ソースコード上の `0.6.1` version metadata を `0.7.0` へ更新する
-- FastAPI metadata / health response の version 表示を `0.7.0` へ更新する
-- `uv lock` 更新要否を確認する
-- `docs/releases/KOIKI-FW_0.7.0.md` を新規作成する
-- README の v0.6 強調を v0.7 現行説明へ更新する
-- 履歴資料の `v0.6.0` / `v0.6.1` 記述は原則維持し、必要な場合のみ履歴資料注記を追加する
+- FastAPI metadata / health response / root response の version 表示を `0.7.0` へ更新する
+- `uv.lock` を更新する
+- `docs/releases/KOIKI-FW_0.7.0.md` の骨子を作成する
+
+#### DM-13-B: `docs/design_kkfw_0.7.0.md` 新規作成
+
+- `docs/design_kkfw_0.6.0.md` は履歴資料として維持する
+- v0.7.0 の正規構成、layered architecture、API ownership、Todo sample 方針、testing、agent guidance を新規文書へまとめる
+- 開発エンジニアが現行構成を判断する入口として扱える内容にする
+
+#### DM-13-C: README / docs の v0.7 現行導線整理
+
+- README の v0.6 強調を v0.7.0 現行説明へ更新する
+- `docs/architecture.md` / `docs/api-spec.md` を `docs/design_kkfw_0.7.0.md` への入口にする
+- agent skill reference docs と testing guide の現行 design doc 参照を更新する
+- 履歴資料の `v0.6.0` / `v0.6.1` 記述は原則維持する
+
+#### DM-13-D: release note 完成
+
+- `docs/releases/KOIKI-FW_0.7.0.md` に主要変更点、compatibility notes、migration notes、validation を記録する
+- `DM-12-C` の `app.main:app` 互換終了判断を release preparation とは分離して残す
+
+### 実施結果
+
+- root `pyproject.toml`、`components/libkoiki/pyproject.toml`、`components/koiki_ref_app/pyproject.toml` を `0.7.0` へ更新した
+- `components/libkoiki/src/libkoiki/__init__.py` の `__version__` を `0.7.0` へ更新した
+- `components/koiki_ref_app/src/koiki_ref_app/app_factory.py` の FastAPI metadata、`/health`、`/` response version を `0.7.0` へ更新した
+- `uv.lock` を更新し、`koiki-pyfw`、`koiki-ref-app`、`libkoiki` の locked version を `0.7.0` へ揃えた
+- `docs/design_kkfw_0.7.0.md` を新規作成した
+- `docs/releases/KOIKI-FW_0.7.0.md` を新規作成した
+- README、`docs/architecture.md`、`docs/api-spec.md`、agent skill references、testing quick guide の現行導線を `docs/design_kkfw_0.7.0.md` へ更新した
 
 ### 完了条件
 
@@ -1205,6 +1234,22 @@ uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent
 ```
 
 必要に応じて、コンテナ build / run 後に health response の version 表示も確認する。
+
+実施済み結果:
+
+```text
+uv lock --check
+  成功
+
+uv run --locked python -c "import libkoiki; print(libkoiki.__version__)"
+  0.7.0
+
+uv run --locked python -c "from koiki_ref_app.asgi import app; print(app.version)"
+  0.7.0
+
+uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent_guidance components/koiki_ref_app/tests tests/integration/services -m "not db_integration"
+  222/259 tests collected, 37 deselected
+```
 
 ## 16. `DM-15` Agent guidance / Skills consistency review
 

--- a/docs/releases/KOIKI-FW_0.7.0.md
+++ b/docs/releases/KOIKI-FW_0.7.0.md
@@ -1,0 +1,99 @@
+# KOIKI-FW v0.7.0 Release Notes
+
+## 概要
+
+KOIKI-FW v0.7.0 は、v0.6 系で整備した認証・監査・Todo sample 基盤を維持しながら、現行開発の正規構成を `components/libkoiki/` と `components/koiki_ref_app/` へ整理した release preparation 版です。
+
+この release では、runtime / package metadata を `0.7.0` に揃え、開発者向け設計文書、README、agent guidance、API ownership 方針を v0.7 構成へ合わせます。
+
+## 主要変更点
+
+### v0.7 backend structure
+
+- reusable framework layer を `components/libkoiki/` に整理
+- reference application backend layer を `components/koiki_ref_app/` に整理
+- root `app/` を `app.main:app` compatibility wrapper として限定
+- `apps/` を downstream / customer-specific backend API の予約領域として明確化
+- root `libkoiki/setup.py` など v0.6 由来の混同要素を整理済み
+
+### API ownership policy
+
+- framework API は reusable capability または明示された starter/sample capability に限定
+- reference app API は current project の workflow / integration / UI-facing behavior を所有
+- downstream customer-specific API は `apps/` から開始
+- Todo API は `libkoiki` の framework sample / starter capability として暫定維持
+- Todo API を新規 business API の `libkoiki` 配置前例として扱わない方針を明文化
+
+### Security and dependency maintenance
+
+- `passlib` 依存を runtime dependency から削除し、password hashing backend を `bcrypt` 直利用へ移行
+- SAML metadata XML parser を hardening
+- `pip-audit` / Bandit の検出結果と false positive 方針を整理
+- Pydantic v2 deprecation 対応を進め、schema / settings / `.dict()` 周辺の warning を削減
+
+### Developer experience
+
+- `uv` / component package / current test layout を現行導線として整理
+- Alembic 実行 path と DB host 使い分けを明確化
+- VSCode pytest discovery を current component test layout に整合
+- `docs/design_kkfw_0.7.0.md` を新規作成し、開発者向け v0.7 アーキテクチャ正本を追加
+- README の v0.6 強調を v0.7 現行説明へ更新
+
+### Agent guidance
+
+- `docs/agent/` と `docs/agent/skills/` を shared guidance / canonical Agent Skills として整理
+- `.claude/skills/` は canonical skill への thin wrapper として維持
+- GitHub Copilot instructions に API ownership / layer boundary を反映
+- prompt catalog / smoke checklist / repository-side contract tests を拡充
+
+## Compatibility Notes
+
+- `koiki_ref_app.asgi:app` が標準 ASGI entrypoint です。
+- `app.main:app` は互換 wrapper として v0.7.0 時点では維持します。
+- `app.main:app` 互換終了判断は v0.7.0 release preparation 後の `DM-12-C` で扱います。
+- `docs/design_kkfw_0.6.0.md` と v0.6 release docs は履歴資料として維持します。
+
+## Migration Notes
+
+v0.6 系の root `app/` / root `libkoiki/` 前提で作業していた場合は、v0.7.0 では次を優先してください。
+
+- framework changes: `components/libkoiki/`
+- reference app backend changes: `components/koiki_ref_app/`
+- downstream customer-specific changes: `apps/`
+- ASGI startup: `koiki_ref_app.asgi:app`
+- Alembic config: `components/koiki_ref_app/alembic.ini`
+
+## Validation
+
+Release preparation validation:
+
+```powershell
+uv lock --check
+uv run --locked python -c "import libkoiki; print(libkoiki.__version__)"
+uv run --locked python -c "from koiki_ref_app.asgi import app; print(app.version)"
+uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent_guidance components/koiki_ref_app/tests tests/integration/services -m "not db_integration"
+```
+
+Optional container validation:
+
+```powershell
+.\start-docker.ps1 unified-prod-build
+.\start-docker.ps1 unified-prod
+```
+
+Confirm:
+
+- container health
+- password login
+- Todo list / create / update
+- backend logs without import/runtime errors
+- `/health` reports version `0.7.0`
+
+## Related Documents
+
+- `docs/design_kkfw_0.7.0.md`
+- `docs/dev/deferred-maintenance-tasks.ja.md`
+- `docs/dev/dm12-legacy-compatibility-inventory.ja.md`
+- `docs/dev/dm14-api-ownership-boundary-policy.ja.md`
+- `docs/dev/dm15-agent-guidance-skills-consistency.ja.md`
+- `docs/agent/`

--- a/docs/testing/QUICK_TEST_GUIDE.md
+++ b/docs/testing/QUICK_TEST_GUIDE.md
@@ -114,7 +114,7 @@ bash scripts/security_test_manager.sh db-check
 
 - 詳細なテスト手順: `ops/README.md`
 - API仕様: http://localhost:8000/docs （環境起動後）
-- システム設計: `docs/design_kkfw_0.6.0.md`
+- システム設計: `docs/design_kkfw_0.7.0.md`
 
 ---
 **🎉 Happy Testing with KOIKI-FW!**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koiki-pyfw"
-version = "0.6.1"
+version = "0.7.0"
 description = "FastAPI enterprise application framework"
 readme = "README.md"
 requires-python = ">=3.11.7,<4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -748,7 +748,7 @@ wheels = [
 
 [[package]]
 name = "koiki-pyfw"
-version = "0.6.1"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -851,7 +851,7 @@ test = [
 
 [[package]]
 name = "koiki-ref-app"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "components/koiki_ref_app" }
 dependencies = [
     { name = "defusedxml" },
@@ -866,7 +866,7 @@ requires-dist = [
 
 [[package]]
 name = "libkoiki"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "components/libkoiki" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

DM-13: v0.7.0 release preparation として、runtime / package metadata と release / architecture docs を v0.7.0 に揃えました。

主な対応:

- root / component package metadata を `0.7.0` へ更新
- `libkoiki.__version__` を `0.7.0` へ更新
- FastAPI metadata、`/health`、`/` の version 表示を `0.7.0` へ更新
- `uv.lock` を `0.7.0` metadata に同期
- `docs/design_kkfw_0.7.0.md` を新規作成
- `docs/releases/KOIKI-FW_0.7.0.md` を新規作成
- README / `docs/architecture.md` / `docs/api-spec.md` を v0.7.0 現行導線へ更新
- agent skill references / testing quick guide の design doc 参照を `docs/design_kkfw_0.7.0.md` へ更新
- `docs/dev/deferred-maintenance-tasks.ja.md` に DM-13-A〜D の詳細化と実施結果を反映

## Commit Split

```text
caec8da chore: bump KOIKI-FW version to 0.7.0
3da2a22 docs: add v0.7.0 release and architecture guidance
```

## Validation

```powershell
$env:UV_CACHE_DIR='.uv-cache-codex'
uv lock --check
```

Result: success.

```powershell
$env:UV_CACHE_DIR='.uv-cache-codex'
$env:DEBUG='true'
uv run --locked python -c "import libkoiki; print(libkoiki.__version__)"
```

Result:

```text
0.7.0
```

```powershell
$env:UV_CACHE_DIR='.uv-cache-codex'
$env:DEBUG='true'
uv run --locked python -c "from koiki_ref_app.asgi import app; print(app.version)"
```

Result:

```text
0.7.0
```

```powershell
$env:UV_CACHE_DIR='.uv-cache-codex'
$env:DEBUG='true'
uv run --locked pytest --collect-only components/libkoiki/tests tests/unit/agent_guidance components/koiki_ref_app/tests tests/integration/services -m "not db_integration"
```

Result:

```text
222/259 tests collected, 37 deselected
```

```powershell
$env:UV_CACHE_DIR='.uv-cache-codex'
$env:DEBUG='true'
uv run --locked pytest tests/unit/agent_guidance
```

Result:

```text
17 passed
```

```powershell
git diff --check HEAD~2..HEAD
```

Result: no errors.

## Container Smoke

User-side container smoke was performed after build/run:

- containers healthy
- password login successful
- Todo list / create / update successful
- `/health` returns `version: "0.7.0"`
- `/` returns `version: "0.7.0"`
- backend logs show no `Traceback`, `ERROR`, `CRITICAL`, `ImportError`, or `ModuleNotFoundError`

Known unrelated warning remains:

```text
InsecureKeyLengthWarning: The HMAC key is 27 bytes long...
```

This is the existing JWT secret length warning and is unrelated to this DM-13 change.

## Notes

- `docs/design_kkfw_0.6.0.md` and v0.6 release docs are preserved as historical references.
- `app.main:app` compatibility removal is intentionally left for the later DM-12-C task.
