### PR TITLE
fix: update dependabot configuration for weekly schedules and limit o…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,40 +1,160 @@
 version: 2
+
 updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "05:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 8
+    open-pull-requests-limit: 3
     labels:
       - "dependencies"
       - "backend"
+      - "dependabot"
     groups:
-      backend-patch:
+      backend-safe-patch:
         patterns:
-          - "*"
+          - "tzdata"
+          - "email-validator"
+          - "defusedxml"
+          - "limits"
+          - "prometheus-fastapi-instrumentator"
+          - "structlog"
+          - "pytest"
+          - "pytest-asyncio"
+          - "pytest-cov"
+          - "pytest-mock"
+          - "PyYAML"
+          - "pip-audit"
+          - "bandit"
         update-types:
           - "patch"
-          - "minor"
+    ignore:
+      # Version updates are intentionally limited to patch releases.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+      # Core framework/runtime
+      - dependency-name: "fastapi"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "uvicorn"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+      # Data / ORM / migration
+      - dependency-name: "sqlalchemy"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "asyncpg"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "alembic"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "psycopg2-binary"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "aiosqlite"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+      # Validation / settings
+      - dependency-name: "pydantic"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "pydantic-settings"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+      # Security / auth / SAML
+      - dependency-name: "PyJWT"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "bcrypt"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "python3-saml"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "xmlsec"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+      # HTTP / integration / cache
+      - dependency-name: "httpx"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "python-multipart"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "redis"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "slowapi"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+      # Workspace packages
+      - dependency-name: "libkoiki"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "koiki-ref-app"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "06:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 8
+    open-pull-requests-limit: 3
     labels:
       - "dependencies"
       - "frontend"
+      - "dependabot"
     groups:
       frontend-patch:
         patterns:
           - "*"
         update-types:
           - "patch"
-          - "minor"
+    ignore:
+      # Version updates are intentionally limited to patch releases.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -46,6 +166,7 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+      - "dependabot"
 
   - package-ecosystem: "docker"
     directory: "/frontend"
@@ -58,6 +179,7 @@ updates:
       - "dependencies"
       - "docker"
       - "frontend"
+      - "dependabot"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -69,3 +191,4 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+      - "dependabot"


### PR DESCRIPTION
## 概要

Dependabot の更新設定を、現行のリポジトリ運用に合わせて保守的な内容へ調整します。

主な目的は、依存更新 PR の大量発生と依存競合による CI 失敗を抑えつつ、軽微な更新提案は継続して受け取れる状態にすることです。

## 変更内容

- backend `uv` の Dependabot 実行頻度を daily から weekly に変更
- backend `uv` の open PR 上限を 8 から 3 に縮小
- backend は安全に追随しやすい補助依存・開発系依存を patch 更新グループに整理
- backend の minor / major 更新は原則 ignore
- `uvicorn`, `python3-saml`, `xmlsec`, workspace package は patch も含めて自動更新対象から除外
- frontend `npm` の実行頻度を daily から weekly に変更
- frontend `npm` の open PR 上限を 8 から 3 に縮小
- frontend は patch 更新のみを自動提案対象に制限
- Docker / GitHub Actions は weekly のまま維持
- Dependabot PR に `dependabot` label を付与

## 運用方針

基盤中核依存は Dependabot による自動追随ではなく、必要時に人手で計画的に更新します。

一方で、補助依存・開発ツール・frontend patch・Docker・GitHub Actions については、Dependabot による週次確認を残します。

これにより、以下のバランスを狙います。

- PR ノイズを抑制する
- 依存競合による CI 失敗を減らす
- Dependabot を完全停止せず、軽微更新の検知は継続する
- GitHub Enterprise 展開時に説明しやすい運用にする

## 確認

- GitHub Actions CI 通過確認済み
- `uv.lock` 整合性チェック通過
- backend unit / integration tests 通過

## 補足

Dependabot の実運用確認は、main マージ後に default branch 上の `.github/dependabot.yml` が参照されてから行われます。

マージ直後に Dependabot の再チェックが走る可能性がありますが、定期実行としては設定された週次スケジュールで確認されます。
