### PR TITLE
fix: update PyJWT dependency pattern to include patch version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,8 +82,9 @@ updates:
           - "version-update:semver-major"
 
       # Security / auth / SAML
-      - dependency-name: "PyJWT"
+      - dependency-name: "pyjwt*"
         update-types:
+          - "version-update:semver-patch"
           - "version-update:semver-minor"
           - "version-update:semver-major"
       - dependency-name: "bcrypt"


### PR DESCRIPTION
## 概要

Dependabot の `uv` 更新で `pyjwt[crypto]` が `dependency_file_content_not_changed` となる問題への対応です。

## 変更内容

- `PyJWT` の ignore 指定を `pyjwt*` に変更
- `pyjwt[crypto]` を含む pyjwt 系依存を Dependabot 自動更新対象から除外
- patch / minor / major すべてを除外対象に追加

## 背景

Dependabot のログでは対象依存が `pyjwt[crypto]` として扱われており、既存の `dependency-name: "PyJWT"` 指定では ignore が期待どおり効かない可能性がありました。

認証・セキュリティ系依存は人手で計画更新する方針のため、pyjwt 系も自動更新から外します。

## 確認

- `.github/dependabot.yml` の YAML parse 確認済み
- Dependabot 対象 ecosystem の読み取り確認済み
