### PR TITLE
fix: update dependabot configuration to include additional allowed de…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,23 @@ updates:
       - "dependencies"
       - "backend"
       - "dependabot"
+    allow:
+      # Only these uv dependencies receive version-update PRs.
+      # Core runtime, auth/security, DB, and workspace dependencies are updated manually.
+      - dependency-name: "tzdata"
+      - dependency-name: "email-validator"
+      - dependency-name: "defusedxml"
+      - dependency-name: "limits"
+      - dependency-name: "prometheus-fastapi-instrumentator"
+      - dependency-name: "structlog"
+      - dependency-name: "python-multipart"
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-asyncio"
+      - dependency-name: "pytest-cov"
+      - dependency-name: "pytest-mock"
+      - dependency-name: "pyyaml"
+      - dependency-name: "pip-audit"
+      - dependency-name: "bandit"
     groups:
       backend-safe-patch:
         patterns:
@@ -22,11 +39,12 @@ updates:
           - "limits"
           - "prometheus-fastapi-instrumentator"
           - "structlog"
+          - "python-multipart"
           - "pytest"
           - "pytest-asyncio"
           - "pytest-cov"
           - "pytest-mock"
-          - "PyYAML"
+          - "pyyaml"
           - "pip-audit"
           - "bandit"
         update-types:
@@ -38,95 +56,8 @@ updates:
           - "version-update:semver-minor"
           - "version-update:semver-major"
 
-      # Core framework/runtime
-      - dependency-name: "fastapi"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "uvicorn"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-
-      # Data / ORM / migration
-      - dependency-name: "sqlalchemy"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "asyncpg"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "alembic"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "psycopg2-binary"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "aiosqlite"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-
-      # Validation / settings
-      - dependency-name: "pydantic"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "pydantic-settings"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-
-      # Security / auth / SAML
+      # Keep pyjwt extras out of Dependabot updates explicitly; uv logs this as pyjwt[crypto].
       - dependency-name: "pyjwt*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "bcrypt"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "python3-saml"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "xmlsec"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-
-      # HTTP / integration / cache
-      - dependency-name: "httpx"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "python-multipart"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "redis"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "slowapi"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-
-      # Workspace packages
-      - dependency-name: "libkoiki"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-minor"
-          - "version-update:semver-major"
-      - dependency-name: "koiki-ref-app"
         update-types:
           - "version-update:semver-patch"
           - "version-update:semver-minor"


### PR DESCRIPTION
## 概要

Dependabot の `uv` 更新設定を、allow-list ベースの一貫した定義へ整理します。

局所的な ignore 追加が続いていたため、backend 依存更新の方針を明確化し、Dependabot が更新候補にする依存を限定します。

## 変更内容

- backend `uv` に `allow` を追加
- Dependabot version update 対象を補助依存・開発系依存に限定
- `allow` と `backend-safe-patch` group の対象依存を一致させる
- `PyYAML` 表記を lockfile 上の正規化名に合わせて `pyyaml` に変更
- `python-multipart` を patch 更新対象グループに明示追加
- allow-list 外の core runtime / auth-security / DB / workspace 依存は手動更新方針に整理
- `pyjwt[crypto]` 対策として `pyjwt*` の patch / minor / major 更新を明示除外
- 既に allow-list で除外される依存の冗長な個別 ignore を削除

## 方針

backend `uv` は以下の方針に統一します。

- 自動更新対象は allow-list に載せた依存のみ
- 自動更新は patch のみ
- minor / major は全体で除外
- 認証・セキュリティ・DB・framework 中核依存は人手で計画更新

## 確認

- `.github/dependabot.yml` の YAML parse 確認済み
- `uv` allow 件数と `backend-safe-patch` group 件数が一致することを確認済み
- Dependabot 対象 ecosystem の読み取り確認済み
