### PR TITLE
ci: update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13.13"
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload HTML coverage report (optional)
         if: ${{ env.ACT != 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: html-coverage-report
           path: htmlcov


### PR DESCRIPTION
## 概要

GitHub Actions の Node.js 20 runtime deprecation warning への対応です。

CI workflow で利用している公式 actions を Node.js 24 対応版へ更新します。

## 変更内容

- `actions/checkout@v4` を `actions/checkout@v5` に更新
- `actions/setup-python@v5` を `actions/setup-python@v6` に更新
- `actions/upload-artifact@v4` を `actions/upload-artifact@v6` に更新

## 背景

GitHub Actions runner では Node.js 20 actions が非推奨となっており、2026年6月2日以降は Node.js 24 が既定、2026年9月16日には Node.js 20 が runner から削除予定です。

そのため、警告対象になっていた公式 actions を Node.js 24 対応版へ更新します。

## 確認

- `.github/workflows/ci.yml` の YAML parse 確認済み
- 変更対象は CI workflow の actions version のみ
- `dev/v0.7` 起点の topic branch として作成
