### PR TITLE
Topic/starlette security update

### DIFF
--- a/components/libkoiki/pyproject.toml
+++ b/components/libkoiki/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 # Enterprise-grade dependency management with strict versioning
 dependencies = [
     # Core Web Framework - Latest stable with security patches
-    "fastapi>=0.136.1,<0.137.0",          # Updated to allow Starlette security fixes
+    "fastapi>=0.136.3,<0.137.0",          # Updated to allow Starlette security fixes
+    "starlette>=1.1.0,<1.2.0",            # Direct dependency: middleware imports Starlette APIs directly
     "uvicorn>=0.34.3,<0.35.0",            # Updated ASGI server (major performance improvements)
     
     # Database Layer - Critical for data integrity

--- a/docs/dev/starlette-fastapi-security-update-plan.ja.md
+++ b/docs/dev/starlette-fastapi-security-update-plan.ja.md
@@ -316,3 +316,77 @@ uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests 
 - `HTTP_422_UNPROCESSABLE_ENTITY` deprecation warning
 
 いずれも今回の Starlette / FastAPI 更新で新規に発生した失敗ではない。
+
+## 12. 残件脆弱性対応結果
+
+実施日: 2026-05-28
+
+`Starlette / FastAPI` 更新後に残っていた `pip-audit` 検出を、lockfile 更新で解消した。
+
+実施内容:
+
+- `idna 3.13 -> 3.16`
+- `mako 1.3.11 -> 1.3.12`
+- `pip 26.0.1 -> 26.1.1`
+- `python-multipart 0.0.26 -> 0.0.29`
+- `urllib3 2.6.3 -> 2.7.0`
+
+依存元分類:
+
+- `python-multipart`: root direct runtime dependency
+- `idna`: `anyio` / `httpx` / `email-validator` / `requests` 経由
+- `mako`: `alembic` 経由
+- `urllib3`: `requests` 経由。主に `pip-audit` / `cachecontrol` 側
+- `pip`: `pip-audit` / `pip-api` 側
+
+解決確認:
+
+```text
+uv lock --upgrade-package idna --upgrade-package mako --upgrade-package python-multipart --upgrade-package urllib3 --upgrade-package pip
+  Updated idna v3.13 -> v3.16
+  Updated mako v1.3.11 -> v1.3.12
+  Updated pip v26.0.1 -> v26.1.1
+  Updated python-multipart v0.0.26 -> v0.0.29
+  Updated urllib3 v2.6.3 -> v2.7.0
+
+uv lock --check
+  Resolved 85 packages
+
+uv run --locked python -c "import importlib.metadata as m; ..."
+  idna 3.16
+  mako 1.3.12
+  pip 26.1.1
+  python-multipart 0.0.29
+  urllib3 2.7.0
+```
+
+監査結果:
+
+```text
+uv run --locked pip-audit
+  No known vulnerabilities found
+
+Name          Skip Reason
+------------- ----------------------------------------------------------------------------
+koiki-ref-app Dependency not found on PyPI and could not be audited: koiki-ref-app (0.7.0)
+libkoiki      Dependency not found on PyPI and could not be audited: libkoiki (0.7.0)
+```
+
+検証結果:
+
+```text
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py components/koiki_ref_app/tests/unit/app/test_saml_auth_logging.py
+  35 passed
+
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/api/test_auth_logging.py
+  7 passed
+
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/test_sso_auth_logging.py
+  16 passed
+
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+  204 passed, 1 skipped, 11 deselected
+```
+
+既知 warning は 11 章と同じ。
+今回の残件脆弱性対応で新規の test failure は確認されていない。

--- a/docs/dev/starlette-fastapi-security-update-plan.ja.md
+++ b/docs/dev/starlette-fastapi-security-update-plan.ja.md
@@ -1,0 +1,318 @@
+# Starlette / FastAPI セキュリティ依存更新計画
+
+作成日: 2026-05-28
+
+関連:
+
+- `docs/dev/dm08-dm10-security-task-plan.ja.md`
+- `docs/dev/deferred-maintenance-tasks.ja.md`
+- `docs/security/SECURITY_AUDIT_COMMANDS.md`
+- `pyproject.toml`
+- `components/libkoiki/pyproject.toml`
+
+## 1. 目的
+
+`pip-audit` で検出された `starlette 0.52.1 / PYSEC-2026-161` を解消するため、Starlette を `1.1.0` へ更新する。
+
+あわせて FastAPI は `0.136.3` を前提に更新する。
+
+今回の主目的は Starlette の脆弱性解消であり、Prometheus 連携は現状 optional として扱う。
+
+## 2. 現状
+
+監査結果:
+
+```text
+starlette 0.52.1 PYSEC-2026-161 1.0.1
+```
+
+確認済みの依存関係:
+
+- `fastapi==0.136.3` は `starlette>=0.46.0` を要求し、Starlette 1.1.0 と依存制約上は両立する。
+- `starlette==1.1.0` は Python `>=3.10` を要求し、本プロジェクトの `>=3.11.7,<4.0` と両立する。
+- `prometheus-fastapi-instrumentator==7.1.0` は `starlette<1.0.0,>=0.30.0` を要求するため、Starlette 1.1.0 と両立しない。
+- 2026-05-28 時点で `prometheus-fastapi-instrumentator` の PyPI 最新は `7.1.0` であり、Starlette 1.x 対応版は未確認。
+
+コード確認結果:
+
+- `components/libkoiki/src/libkoiki/core/monitoring.py` は `prometheus_fastapi_instrumentator` / `prometheus_client` の import 失敗時に dummy 実装へ fallback する。
+- `components/koiki_ref_app/src/koiki_ref_app/app_factory.py` は `setup_monitoring` を import しているが、現状 `create_app()` 内で呼び出していない。
+- Prometheus package 不在を模擬した import と `setup_monitoring(app)` 実行は成功し、`/metrics` が登録されないだけで runtime error にはならない。
+
+## 3. 方針
+
+Starlette 1.1.0 を優先する。
+
+そのため、短期対応として `prometheus-fastapi-instrumentator` を direct dependency から外す。
+
+理由:
+
+- `PYSEC-2026-161` は runtime web framework 側の脆弱性であり、優先度が高い。
+- 現状の Prometheus 連携は app startup で有効化されていない。
+- `monitoring.py` に package 不在時の fallback が実装済みである。
+- `prometheus-fastapi-instrumentator` の現行最新版は Starlette 1.x と依存制約上衝突する。
+
+## 4. 変更対象
+
+### root dependency
+
+`pyproject.toml`:
+
+- `fastapi>=0.136.1,<0.137.0` を `fastapi>=0.136.3,<0.137.0` へ更新する。
+- `starlette>=1.1.0,<1.2.0` を direct dependency として追加する。
+- `prometheus-fastapi-instrumentator>=7.1.0,<7.2.0` を削除する。
+
+### libkoiki dependency
+
+`components/libkoiki/pyproject.toml`:
+
+- `fastapi>=0.136.1,<0.137.0` を `fastapi>=0.136.3,<0.137.0` へ更新する。
+- `starlette>=1.1.0,<1.2.0` を direct dependency として追加する。
+
+理由:
+
+- `components/libkoiki/src/libkoiki/core/middleware.py` は `starlette.middleware.base` / `starlette.responses` / `starlette.types` を直接 import している。
+- Starlette は FastAPI の transitive dependency ではなく、`libkoiki` の direct dependency として明示するのが妥当である。
+
+### lockfile
+
+`uv.lock`:
+
+- `fastapi` を `0.136.3` へ更新する。
+- `starlette` を `1.1.0` へ更新する。
+- `prometheus-fastapi-instrumentator` が不要になっていることを確認する。
+- `prometheus-client` が他の direct/transitive dependency から必要か確認する。
+
+## 5. 実施手順
+
+1. 変更前の監査結果を保存する。
+
+```powershell
+uv run --locked pip-audit --format=json --output=pip-audit-starlette-before.json
+uv run --locked pip-audit
+uv tree
+```
+
+2. `pyproject.toml` と `components/libkoiki/pyproject.toml` を更新する。
+
+3. lockfile を更新する。
+
+```powershell
+uv lock --upgrade-package fastapi --upgrade-package starlette
+uv sync --locked --group dev --group test --group security
+uv lock --check
+```
+
+4. 解決後のバージョンを確認する。
+
+```powershell
+uv run --locked python -c "import fastapi, starlette; print(fastapi.__version__, starlette.__version__)"
+uv tree | Select-String -Pattern "fastapi|starlette|prometheus"
+```
+
+期待値:
+
+```text
+fastapi 0.136.3
+starlette 1.1.0
+```
+
+5. 変更後の監査結果を取得する。
+
+```powershell
+uv run --locked pip-audit --format=json --output=pip-audit-starlette-after.json
+uv run --locked pip-audit
+```
+
+## 6. 検証範囲
+
+### 最小確認
+
+```powershell
+$env:DEBUG='False'
+uv lock --check
+uv run --locked python -c "from koiki_ref_app.asgi import app; print(app.version)"
+uv run --locked pytest components/libkoiki/tests/unit/core/test_audit_middleware.py
+```
+
+### FastAPI / Starlette 回帰確認
+
+```powershell
+$env:DEBUG='False'
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+```
+
+### auth / SSO / SAML 重点確認
+
+```powershell
+$env:DEBUG='False'
+uv run --locked pytest components/koiki_ref_app/tests/integration/app/api/test_auth_api.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_sso_service.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/test_sso_auth_logging.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/test_saml_auth_logging.py
+```
+
+### Prometheus optional fallback 確認
+
+`prometheus-fastapi-instrumentator` を外した後、次が失敗しないことを確認する。
+
+```powershell
+$env:DEBUG='False'
+uv run --locked python -c "from libkoiki.core.monitoring import PROMETHEUS_AVAILABLE, increment_user_registration; print(PROMETHEUS_AVAILABLE); increment_user_registration(); print('ok')"
+uv run --locked python -c "from fastapi import FastAPI; from libkoiki.core.monitoring import setup_monitoring; app=FastAPI(); setup_monitoring(app); print([r.path for r in app.routes])"
+```
+
+期待値:
+
+- `PROMETHEUS_AVAILABLE` は `False`
+- import / counter increment / `setup_monitoring(app)` は成功する
+- `/metrics` は登録されない
+
+## 7. 完了条件
+
+- `fastapi` が `0.136.3` に更新されている。
+- `starlette` が `1.1.0` に更新されている。
+- `prometheus-fastapi-instrumentator` が runtime dependency から外れている。
+- `uv lock --check` が成功する。
+- `PYSEC-2026-161` が `pip-audit` 結果から消えている。
+- Prometheus package 不在時も `libkoiki.core.monitoring` の import と fallback が機能する。
+- middleware / auth / SSO / SAML の主要テストが通っている。
+
+## 8. 残件の扱い
+
+Starlette 更新後も、監査結果には他 package の検出が残る可能性がある。
+
+現時点の既知候補:
+
+- `idna 3.13 -> 3.15`
+- `mako 1.3.11 -> 1.3.12`
+- `pip 26.0.1 -> 26.1`
+- `python-multipart 0.0.26 -> 0.0.27`
+- `urllib3 2.6.3 -> 2.7.0`
+
+今回の PR で扱うかは、Starlette / FastAPI 更新の差分が安定した後に判断する。
+
+原則:
+
+- Starlette 脆弱性解消を最優先にする。
+- 追加更新が lockfile のみで済み、回帰範囲が広がらないものは同時対応を検討する。
+- FastAPI / Starlette と無関係な残件は、別 PR または別タスクとして記録してもよい。
+- `pip` は runtime dependency か、監査実行環境側 dependency かを切り分けて記録する。
+
+## 9. 後続判断
+
+### Prometheus 連携
+
+`prometheus-fastapi-instrumentator` の Starlette 1.x 対応版が公開されたら、再導入を検討する。
+
+再導入時の条件:
+
+- Starlette 1.x と依存制約上両立する。
+- `setup_monitoring(app)` を有効化するかどうかを明示する。
+- `/metrics` endpoint の公開要否、OpenAPI schema への含有要否、production exposure policy を決める。
+- monitoring endpoint のテストを追加する。
+
+### 代替 monitoring
+
+`prometheus-fastapi-instrumentator` の対応が遅い場合は、次を比較する。
+
+- `prometheus_client` 直利用
+- ASGI middleware 自作
+- OpenTelemetry metrics への移行
+
+この判断は Starlette 脆弱性対応 PR には含めない。
+
+## 10. 注意事項
+
+- `components/libkoiki/` の reusable framework behavior と `components/koiki_ref_app/` の reference app composition を混ぜない。
+- Prometheus 連携を外す変更は、monitoring capability の削除ではなく、Starlette 1.x 非対応 package の一時除外として扱う。
+- `setup_monitoring(app)` を新たに有効化しない。
+- root `app/` は compatibility wrapper として扱い、新規実装を追加しない。
+- Codex 環境では `DEBUG=release` が混入する場合があるため、検証時は `DEBUG=True` または `DEBUG=False` を明示する。
+
+## 11. 実施結果
+
+実施日: 2026-05-28
+
+実施内容:
+
+- `pyproject.toml`
+  - `fastapi>=0.136.3,<0.137.0` へ更新した。
+  - `starlette>=1.1.0,<1.2.0` を direct dependency として追加した。
+  - `prometheus-fastapi-instrumentator>=7.1.0,<7.2.0` を削除した。
+- `components/libkoiki/pyproject.toml`
+  - `fastapi>=0.136.3,<0.137.0` へ更新した。
+  - `starlette>=1.1.0,<1.2.0` を direct dependency として追加した。
+- `uv.lock`
+  - `fastapi 0.136.1 -> 0.136.3`
+  - `starlette 0.52.1 -> 1.1.0`
+  - `prometheus-fastapi-instrumentator 7.1.0` を削除
+  - `prometheus-client 0.25.0` を削除
+
+解決確認:
+
+```text
+uv lock --check
+  Resolved 85 packages
+
+uv run --locked python -c "import fastapi, starlette; print(fastapi.__version__, starlette.__version__)"
+  0.136.3 1.1.0
+```
+
+Prometheus optional fallback 確認:
+
+```text
+from libkoiki.core.monitoring import PROMETHEUS_AVAILABLE, increment_user_registration
+  PROMETHEUS_AVAILABLE=False
+  increment_user_registration() 成功
+
+setup_monitoring(FastAPI()) 実行
+  Prometheus monitoring disabled - package not installed
+  /metrics は登録されない
+```
+
+`pip-audit` 結果:
+
+```text
+Found 7 known vulnerabilities in 5 packages
+
+idna             3.13    CVE-2026-45409 3.15
+mako             1.3.11  CVE-2026-44307 1.3.12
+pip              26.0.1  CVE-2026-3219  26.1
+pip              26.0.1  CVE-2026-6357  26.1
+python-multipart 0.0.26  CVE-2026-42561 0.0.27
+urllib3          2.6.3   PYSEC-2026-142 2.7.0
+urllib3          2.6.3   PYSEC-2026-141 2.7.0
+```
+
+`starlette / PYSEC-2026-161` は検出結果から消えた。
+
+検証結果:
+
+```text
+uv run --locked python -c "from koiki_ref_app.asgi import app; print(app.version)"
+  0.7.0
+
+uv run --locked pytest components/libkoiki/tests/unit/core/test_audit_middleware.py
+  6 passed
+
+uv run --locked pytest components/koiki_ref_app/tests/integration/app/api/test_auth_api.py
+  11 skipped
+
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/test_sso_auth_logging.py
+  16 passed
+
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py components/koiki_ref_app/tests/unit/app/test_saml_auth_logging.py
+  35 passed
+
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+  204 passed, 1 skipped, 11 deselected
+```
+
+既知 warning:
+
+- `components/libkoiki/src/libkoiki/core/transaction.py` と `AsyncMock` の組み合わせによる既存 `RuntimeWarning`
+- `HTTP_422_UNPROCESSABLE_ENTITY` deprecation warning
+
+いずれも今回の Starlette / FastAPI 更新で新規に発生した失敗ではない。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 # All runtime dependencies with strict version control for production stability
 dependencies = [
     # Core Web Framework
-    "fastapi>=0.136.1,<0.137.0",            # Updated to allow Starlette security fixes
+    "fastapi>=0.136.3,<0.137.0",            # Updated to allow Starlette security fixes
+    "starlette>=1.1.0,<1.2.0",              # Direct dependency: libkoiki imports Starlette APIs directly
     "uvicorn>=0.34.3,<0.35.0",              # Updated ASGI server (major performance improvements)
     
     # Database Layer (Python 3.13 compatible)
@@ -54,7 +55,6 @@ dependencies = [
     
     # Logging & Monitoring
     "structlog>=25.4.0,<25.5.0",            # Updated structured logging
-    "prometheus-fastapi-instrumentator>=7.1.0,<7.2.0", # Updated monitoring instrumentation
     
     # Caching & Performance
     "redis>=6.2.0,<6.3.0",                  # Updated Redis client (major version)

--- a/uv.lock
+++ b/uv.lock
@@ -721,11 +721,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -1048,14 +1048,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -1226,11 +1226,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]
@@ -1562,11 +1562,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -1880,11 +1880,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.1"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -611,9 +611,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -762,7 +762,6 @@ dependencies = [
     { name = "koiki-ref-app" },
     { name = "libkoiki" },
     { name = "limits" },
-    { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -772,6 +771,7 @@ dependencies = [
     { name = "redis" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "starlette" },
     { name = "structlog" },
     { name = "tzdata" },
     { name = "uvicorn" },
@@ -807,12 +807,11 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
     { name = "bcrypt", specifier = ">=4.3.0,<5.0.0" },
     { name = "email-validator", specifier = ">=2.2.0,<2.3.0" },
-    { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
+    { name = "fastapi", specifier = ">=0.136.3,<0.137.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "koiki-ref-app", editable = "components/koiki_ref_app" },
     { name = "libkoiki", editable = "components/libkoiki" },
     { name = "limits", specifier = ">=5.4.0,<5.5.0" },
-    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0,<7.2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9,<2.10.0" },
     { name = "pydantic", specifier = ">=2.11.7,<2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.10.0,<2.11.0" },
@@ -822,6 +821,7 @@ requires-dist = [
     { name = "redis", specifier = ">=6.2.0,<6.3.0" },
     { name = "slowapi", specifier = ">=0.1.8,<0.2.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.23,<2.1.0" },
+    { name = "starlette", specifier = ">=1.1.0,<1.2.0" },
     { name = "structlog", specifier = ">=25.4.0,<25.5.0" },
     { name = "tzdata", specifier = ">=2024.2,<2026.0" },
     { name = "uvicorn", specifier = ">=0.34.3,<0.35.0" },
@@ -880,6 +880,7 @@ dependencies = [
     { name = "redis" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "starlette" },
     { name = "structlog" },
     { name = "tzdata" },
     { name = "uvicorn" },
@@ -898,7 +899,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.16.2,<1.17.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
     { name = "bcrypt", specifier = ">=4.3.0,<5.0.0" },
-    { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
+    { name = "fastapi", specifier = ">=0.136.3,<0.137.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "pydantic", specifier = ">=2.11.7,<2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.10.0,<2.11.0" },
@@ -910,6 +911,7 @@ requires-dist = [
     { name = "redis", specifier = ">=6.2.0,<6.3.0" },
     { name = "slowapi", specifier = ">=0.1.8,<0.2.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.23,<2.1.0" },
+    { name = "starlette", specifier = ">=1.1.0,<1.2.0" },
     { name = "structlog", specifier = ">=25.4.0,<25.5.0" },
     { name = "tzdata", specifier = ">=2024.2,<2026.0" },
     { name = "uvicorn", specifier = ">=0.34.3,<0.35.0" },
@@ -1293,28 +1295,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
-]
-
-[[package]]
-name = "prometheus-fastapi-instrumentator"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "prometheus-client" },
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
 ]
 
 [[package]]
@@ -1776,15 +1756,15 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Starlette 脆弱性対応を優先し、関連する依存更新を実施しました。

- `fastapi` を `0.136.3` へ更新
- `starlette` を `1.1.0` へ更新し、`PYSEC-2026-161` を解消
- `starlette<1.0.0` 制約と衝突する `prometheus-fastapi-instrumentator` を削除
- `starlette` を `libkoiki` の direct dependency として明示
- 残件の `pip-audit` 検出依存も lock 更新で解消
  - `idna 3.16`
  - `mako 1.3.12`
  - `pip 26.1.1`
  - `python-multipart 0.0.29`
  - `urllib3 2.7.0`
- 対応方針と検証結果を `docs/dev/starlette-fastapi-security-update-plan.ja.md` に記録

## Validation

ローカル:

- `uv lock --check`
- `uv sync --locked --group dev --group test --group security`
- `uv run --locked pip-audit`
  - `No known vulnerabilities found`
- `uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py components/koiki_ref_app/tests/unit/app/test_saml_auth_logging.py`
  - `35 passed`
- `uv run --locked pytest components/libkoiki/tests/unit/libkoiki/api/test_auth_logging.py`
  - `7 passed`
- `uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/test_sso_auth_logging.py`
  - `16 passed`
- `uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"`
  - `204 passed, 1 skipped, 11 deselected`

Container smoke:

- `.\start-docker.ps1 unified-prod-build`
- `.\start-docker.ps1 unified-prod`
- backend / frontend / keycloak / postgres containers are healthy
- backend container versions confirmed:
  - `fastapi 0.136.3`
  - `starlette 1.1.0`
  - `idna 3.16`
  - `mako 1.3.12`
  - `python-multipart 0.0.29`
- password login succeeded
- Todo list/update flow succeeded
- frontend log shows `Login route handler completed successfully`
- backend logs show no effective `Traceback`, `ERROR`, `500`, `ImportError`, or validation failures

## Notes

`prometheus-fastapi-instrumentator` is intentionally removed because the latest available version still requires `starlette<1.0.0`. Current monitoring code already has a fallback path and the Prometheus endpoint is not enabled in app startup.

`UVICORN_WORKERS=4` was observed in the unified compose profile, but worker count tuning is being treated as a separate follow-up task.