### PR TITLE
Dev/env devcontainer koikidev - feat(devcontainer): devcontainer開発環境とVS Codeタスクを追加

### DIFF
--- a/.devcontainer/Dockerfile.devcontainer
+++ b/.devcontainer/Dockerfile.devcontainer
@@ -1,0 +1,48 @@
+FROM python:3.13.13-slim-bookworm
+
+# Custom CA cert (社内証明書対応)
+COPY docker/certs/nscacert.pem /usr/local/share/ca-certificates/nscacert.crt
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    update-ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends \
+        nodejs \
+        make \
+        jq \
+        openssh-client \
+        zip \
+        unzip \
+        tree \
+        procps \
+        iproute2 \
+        iputils-ping && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# uv (バージョンを本番 Dockerfile と揃える)
+COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /usr/local/bin/
+
+ENV UV_CACHE_DIR=/opt/uv-cache \
+    UV_LINK_MODE=copy \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/nscacert.crt
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+RUN groupadd --gid ${USER_GID} ${USERNAME} && \
+    useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} && \
+    mkdir -p /opt/uv-cache && \
+    chown ${USERNAME}:${USERNAME} /opt/uv-cache && \
+    # Anonymous volume の初期化オーナーを vscode に設定する
+    # Docker はイメージ内のパスのオーナー情報を使って anonymous volume を初期化するため、
+    # これらのディレクトリを vscode 所有で作成しておく必要がある。
+    # 未設定の場合 root:root で初期化され postCreateCommand の uv sync / npm install が失敗する。
+    mkdir -p /workspace/.venv /workspace/frontend/node_modules && \
+    chown -R ${USERNAME}:${USERNAME} /workspace
+
+USER ${USERNAME}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,9 @@
 {
   "name": "KOIKI-FW Dev",
-  "dockerComposeFile": [
-    "../docker-compose.yml",
-    "../docker-compose.dev.yml",
-    "docker-compose.devcontainer.yml"
-  ],
-  "service": "app",
-  "workspaceFolder": "/app",
-  "remoteUser": "appuser",
+  "dockerComposeFile": "docker-compose.devcontainer.yml",
+  "service": "workspace",
+  "workspaceFolder": "/workspace",
+  "remoteUser": "vscode",
 
   "features": {
     "ghcr.io/devcontainers/features/git:1": {}
@@ -16,22 +12,27 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        // Python / Backend
         "ms-python.python",
         "ms-python.pylance",
         "ms-python.black-formatter",
         "ms-python.isort",
         "charliermarsh.ruff",
-        "littlefoxteam.vscode-python-test-adapter",
+        // Frontend
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        // Git / Docker
         "ms-azuretools.vscode-docker",
         "donjayamanne.githistory",
         "eamodio.gitlens"
       ],
       "settings": {
-        "python.defaultInterpreterPath": "/app/.venv/bin/python",
+        "python.defaultInterpreterPath": "/workspace/.venv/bin/python",
         "python.analysis.extraPaths": [
-          "/app/app",
-          "/app/components/libkoiki/src",
-          "/app/components/koiki_ref_app/src"
+          "/workspace/app",
+          "/workspace/components/libkoiki/src",
+          "/workspace/components/koiki_ref_app/src"
         ],
         "python.terminal.activateEnvironment": false,
         "python.linting.enabled": false,
@@ -68,6 +69,20 @@
 
   "shutdownAction": "stopCompose",
 
-  "postCreateCommand": "[ -f /app/.env ] || cp /app/.env.example /app/.env && cd /app/components/koiki_ref_app && uv run alembic upgrade head",
-  "postStartCommand": "echo 'Dev container ready. Run: uvicorn koiki_ref_app.asgi:app --host 0.0.0.0 --port 8000 --reload'"
+  // 1. .env がなければ .env.example からコピー
+  // 2. Python 依存関係インストール (uv workspace メンバーを editable インストール)
+  // 3. フロントエンド依存関係インストール
+  // 4. DB マイグレーション適用 (失敗しても非致命的: postStartCommand でリトライする)
+  //
+  // 注意: /workspace/.venv と /workspace/frontend/node_modules は docker-compose.devcontainer.yml の
+  // anonymous volume で遮蔽されており、Dockerfile.devcontainer で vscode:vscode 所有にした
+  // ディレクトリとして初期化される（その修正が適用されたイメージを使用すること）。
+  // DB 接続先 "db" は Docker ネットワーク内のホスト名。alembic は DATABASE_URL が
+  // カレントディレクトリの .env から読まれるため /workspace から実行する。
+  "postCreateCommand": "git config --global --add safe.directory /workspace && [ -f /workspace/.env ] || cp /workspace/.env.example /workspace/.env && cd /workspace && uv sync --locked --group dev --group test && npm --prefix /workspace/frontend install",
+
+  // コンテナ起動のたびに DB マイグレーションを適用する。
+  // postCreateCommand でのトランジェントエラー (Hyper-V ソケットタイムアウト等) から自動回復する。
+  // alembic は idempotent なので重複適用しても安全。
+  "postStartCommand": "git config --global --add safe.directory /workspace && DATABASE_URL=postgresql+asyncpg://koiki_user:koiki_password@db:5432/koiki_todo_db uv run --directory /workspace alembic -c components/koiki_ref_app/alembic.ini upgrade head"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,73 @@
+{
+  "name": "KOIKI-FW Dev",
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "../docker-compose.dev.yml",
+    "docker-compose.devcontainer.yml"
+  ],
+  "service": "app",
+  "workspaceFolder": "/app",
+  "remoteUser": "appuser",
+
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.pylance",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "charliermarsh.ruff",
+        "littlefoxteam.vscode-python-test-adapter",
+        "ms-azuretools.vscode-docker",
+        "donjayamanne.githistory",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/app/.venv/bin/python",
+        "python.analysis.extraPaths": [
+          "/app/app",
+          "/app/components/libkoiki/src",
+          "/app/components/koiki_ref_app/src"
+        ],
+        "python.terminal.activateEnvironment": false,
+        "python.linting.enabled": false,
+        "python.linting.pylintEnabled": false,
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "components/libkoiki/tests",
+          "tests/unit/agent_guidance",
+          "components/koiki_ref_app/tests",
+          "tests/integration/services",
+          "-m",
+          "not db_integration"
+        ],
+        "editor.formatOnSave": true,
+        "[python]": {
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "ms-python.black-formatter",
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+
+  "forwardPorts": [8000, 3000, 5432, 8090],
+  "portsAttributes": {
+    "8000": { "label": "FastAPI Backend" },
+    "3000": { "label": "Next.js Frontend" },
+    "5432": { "label": "PostgreSQL" },
+    "8090": { "label": "Keycloak" }
+  },
+
+  "shutdownAction": "stopCompose",
+
+  "postCreateCommand": "[ -f /app/.env ] || cp /app/.env.example /app/.env && cd /app/components/koiki_ref_app && uv run alembic upgrade head",
+  "postStartCommand": "echo 'Dev container ready. Run: uvicorn koiki_ref_app.asgi:app --host 0.0.0.0 --port 8000 --reload'"
+}

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,18 +1,77 @@
+name: koiki_devcontainer
+
 services:
-  app:
-    # VS Code が接続している間コンテナを維持する (uvicorn は手動または Run/Debug で起動)
-    command: sleep infinity
-    # devcontainer では DB/Keycloak の起動を待たず app に即接続できるようにする
-    depends_on: {}
+  workspace:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile.devcontainer
     volumes:
-      # リポルート全体を /app にマウント (.git / .env / pyproject.toml 等を可視化)
-      - .:/app:cached
-      # Windows の .venv が Linux コンテナに見えてしまうのを anonymous volume で遮蔽
-      - /app/.venv
-      # uv キャッシュをコンテナ内に保持 (再ビルド高速化)
+      # リポジトリ全体を /workspace にマウント
+      - ..:/workspace:cached
+      # Windows の .venv / node_modules が Linux コンテナに見えないよう anonymous volume で遮蔽
+      - /workspace/.venv
+      - /workspace/frontend/node_modules
+      # uv キャッシュをコンテナ内に保持（再ビルド高速化）
       - uv_cache:/opt/uv-cache
+    command: sleep infinity
     environment:
       - APP_ENV=development
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - koiki_dev
+
+  db:
+    image: postgres:15
+    # .env.example のデフォルト値に合わせた初期設定
+    environment:
+      POSTGRES_USER: koiki_user
+      POSTGRES_PASSWORD: koiki_password
+      POSTGRES_DB: koiki_todo_db
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U koiki_user -d koiki_todo_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    command:
+      - "postgres"
+      - "-c"
+      - "max_connections=100"
+      - "-c"
+      - "shared_buffers=256MB"
+    networks:
+      - koiki_dev
+
+  # profiles: [keycloak] により、通常起動では含まれない
+  # 起動する場合: docker compose --profile keycloak up
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.3.5
+    profiles: [keycloak]
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+      KC_METRICS_ENABLED: "true"
+    volumes:
+      - ../docker/keycloak/realm-koiki.json:/opt/keycloak/data/import/realm-koiki.json:ro
+      - ../docker/keycloak/realm-saml.json:/opt/keycloak/data/import/realm-saml.json:ro
+      - keycloak_data:/opt/keycloak/data
+    ports:
+      - "8090:8080"
+      - "9000:9000"
+    networks:
+      - koiki_dev
 
 volumes:
+  postgres_data:
+  keycloak_data:
   uv_cache:
+
+networks:
+  koiki_dev:

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,18 @@
+services:
+  app:
+    # VS Code が接続している間コンテナを維持する (uvicorn は手動または Run/Debug で起動)
+    command: sleep infinity
+    # devcontainer では DB/Keycloak の起動を待たず app に即接続できるようにする
+    depends_on: {}
+    volumes:
+      # リポルート全体を /app にマウント (.git / .env / pyproject.toml 等を可視化)
+      - .:/app:cached
+      # Windows の .venv が Linux コンテナに見えてしまうのを anonymous volume で遮蔽
+      - /app/.venv
+      # uv キャッシュをコンテナ内に保持 (再ビルド高速化)
+      - uv_cache:/opt/uv-cache
+    environment:
+      - APP_ENV=development
+
+volumes:
+  uv_cache:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,56 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Start Backend",
+      "type": "shell",
+      "command": "uv run uvicorn koiki_ref_app.asgi:app --host 0.0.0.0 --port 8000 --reload",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev-servers"
+      },
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Start Frontend",
+      "type": "shell",
+      "command": "npm run dev -- --hostname 0.0.0.0 --port 3000",
+      "options": {
+        "cwd": "${workspaceFolder}/frontend"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev-servers"
+      },
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Start All",
+      "dependsOn": ["Start Backend", "Start Frontend"],
+      "dependsOrder": "parallel",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "DB Migration (upgrade head)",
+      "type": "shell",
+      "command": "uv run alembic upgrade head",
+      "options": {
+        "cwd": "${workspaceFolder}/components/koiki_ref_app"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,10 @@ FROM base AS dev
 RUN adduser --disabled-password --gecos "" appuser
 
 # Alembic versionsディレクトリの作成と所有者変更
-RUN mkdir -p /app/components/koiki_ref_app/alembic/versions && chown -R appuser:appuser /app
+# /opt/uv-cache も appuser に chown する (named volume がroot所有で初期化されるのを防ぐ)
+RUN mkdir -p /app/components/koiki_ref_app/alembic/versions \
+    && chown -R appuser:appuser /app \
+    && chown -R appuser:appuser /opt/uv-cache
 
 # 非rootユーザーに切り替え
 USER appuser

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,6 +33,32 @@ RUN if [ "${FRONTEND_ENV_FILE}" != ".env.production" ] && [ "${FRONTEND_ENV_FILE
 RUN npm run build
 
 # ---------------------
+# Development stage
+# ---------------------
+FROM node:22-slim AS dev
+
+COPY docker/certs/nscacert.pem /usr/local/share/ca-certificates/nscacert.crt
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates wget curl && \
+  update-ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/nscacert.crt \
+  SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+  NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]
+
+# ---------------------
 # Runtime stage
 # ---------------------
 FROM node:22-slim AS runner

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "dev:turbo": "next dev --turbopack",
+    "dev": "next dev --port 3000",
+    "dev:turbo": "next dev --turbopack --port 3000",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",


### PR DESCRIPTION
## 概要

devcontainer ベースの開発環境を追加し、VS Code タスク経由で Backend / Frontend / DB Migration を起動しやすくしました。  
あわせて frontend の開発ポート固定と、Docker 開発時の権限まわりを調整しています。

## 変更内容

- devcontainer 設定追加
- VS Code タスク追加
- frontend 開発ポートを 3000 に固定
- frontend 開発用 Dockerfile 追加
- backend Dockerfile の権限設定調整

## 備考

- 主目的はローカル開発環境の整備です
- 業務ロジックへの影響はありません