### PR TITLE
feat(devcontainer): DB起動待機とマイグレーション再試行を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -72,17 +72,15 @@
   // 1. .env がなければ .env.example からコピー
   // 2. Python 依存関係インストール (uv workspace メンバーを editable インストール)
   // 3. フロントエンド依存関係インストール
-  // 4. DB マイグレーション適用 (失敗しても非致命的: postStartCommand でリトライする)
   //
   // 注意: /workspace/.venv と /workspace/frontend/node_modules は docker-compose.devcontainer.yml の
   // anonymous volume で遮蔽されており、Dockerfile.devcontainer で vscode:vscode 所有にした
   // ディレクトリとして初期化される（その修正が適用されたイメージを使用すること）。
-  // DB 接続先 "db" は Docker ネットワーク内のホスト名。alembic は DATABASE_URL が
-  // カレントディレクトリの .env から読まれるため /workspace から実行する。
   "postCreateCommand": "git config --global --add safe.directory /workspace && [ -f /workspace/.env ] || cp /workspace/.env.example /workspace/.env && cd /workspace && uv sync --locked --group dev --group test && npm --prefix /workspace/frontend install",
 
   // コンテナ起動のたびに DB マイグレーションを適用する。
-  // postCreateCommand でのトランジェントエラー (Hyper-V ソケットタイムアウト等) から自動回復する。
-  // alembic は idempotent なので重複適用しても安全。
-  "postStartCommand": "git config --global --add safe.directory /workspace && DATABASE_URL=postgresql+asyncpg://koiki_user:koiki_password@db:5432/koiki_todo_db uv run --directory /workspace alembic -c components/koiki_ref_app/alembic.ini upgrade head"
+  // DB 接続先 "db" は Docker ネットワーク内のホスト名。接続設定は環境変数で上書きできる。
+  // DB 接続を最大 60 秒待機し、一時的な接続失敗に備えて Alembic を最大 3 回実行する。
+  // 恒久的なマイグレーションエラーは最終試行後に非ゼロで終了する。
+  "postStartCommand": "git config --global --add safe.directory /workspace && /bin/sh /workspace/.devcontainer/scripts/post-start.sh"
 }

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -u
+
+DB_HOST="${DB_HOST:-db}"
+DB_PORT="${DB_PORT:-5432}"
+DB_WAIT_TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
+DB_WAIT_INTERVAL="${DB_WAIT_INTERVAL:-2}"
+MIGRATION_MAX_ATTEMPTS="${MIGRATION_MAX_ATTEMPTS:-3}"
+MIGRATION_RETRY_DELAY="${MIGRATION_RETRY_DELAY:-3}"
+DATABASE_URL="${DATABASE_URL:-postgresql+asyncpg://koiki_user:koiki_password@${DB_HOST}:${DB_PORT}/koiki_todo_db}"
+
+wait_for_db() {
+  deadline=$(( $(date +%s) + DB_WAIT_TIMEOUT ))
+  attempt=1
+
+  while ! python3 -c \
+    'import socket, sys; socket.create_connection((sys.argv[1], int(sys.argv[2])), 2).close()' \
+    "$DB_HOST" "$DB_PORT" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "ERROR: database ${DB_HOST}:${DB_PORT} is unreachable after ${DB_WAIT_TIMEOUT}s" >&2
+      return 1
+    fi
+
+    echo "Waiting for database ${DB_HOST}:${DB_PORT} (attempt ${attempt})..."
+    attempt=$((attempt + 1))
+    sleep "$DB_WAIT_INTERVAL"
+  done
+
+  echo "Database ${DB_HOST}:${DB_PORT} is reachable."
+}
+
+run_migrations() {
+  attempt=1
+
+  while [ "$attempt" -le "$MIGRATION_MAX_ATTEMPTS" ]; do
+    echo "Running database migrations (attempt ${attempt}/${MIGRATION_MAX_ATTEMPTS})..."
+
+    if DATABASE_URL="$DATABASE_URL" uv run --directory /workspace \
+      alembic -c components/koiki_ref_app/alembic.ini upgrade head; then
+      echo "Database migrations completed."
+      return 0
+    else
+      status=$?
+    fi
+
+    if [ "$attempt" -eq "$MIGRATION_MAX_ATTEMPTS" ]; then
+      echo "ERROR: database migrations failed after ${MIGRATION_MAX_ATTEMPTS} attempts" >&2
+      return "$status"
+    fi
+
+    echo "Migration attempt ${attempt} failed; retrying in ${MIGRATION_RETRY_DELAY}s..." >&2
+    attempt=$((attempt + 1))
+    sleep "$MIGRATION_RETRY_DELAY"
+  done
+}
+
+wait_for_db && run_migrations


### PR DESCRIPTION
## 概要

Dev Container起動時のDBマイグレーション処理を専用スクリプトへ分離し、PostgreSQLの起動待機と一時的な失敗時の再試行を追加しました。

## 変更内容

- `.devcontainer/scripts/post-start.sh` を追加
- PostgreSQLへの接続を最大60秒待機
- `alembic upgrade head` を最大3回実行
- DB接続先、待機時間、再試行回数などを環境変数で上書き可能に変更
- 恒久的な接続・マイグレーションエラーでは非ゼロ終了
- `devcontainer.json` の `postStartCommand` からスクリプトを実行

## 確認内容

- Dev Container再接続時に `postStartCommand` が正常終了すること
- PostgreSQLの `db:5432` に接続できること
- `alembic upgrade head` が正常終了すること
- DBの現在リビジョンが最新head `20260228001` と一致すること
- 既存データを初期化せず、未適用マイグレーションのみが適用されること