### PR TITLE
feat(v0.7): dev/v0.7 → main — devcontainer 環境整備・grill-with-docs スキル追加・セキュリティ依存更新

### DIFF
--- a/.agents/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.agents/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.agents/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.agents/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/.claude/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.claude/skills/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
+++ b/.claude/skills/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/.devcontainer/Dockerfile.devcontainer
+++ b/.devcontainer/Dockerfile.devcontainer
@@ -1,0 +1,48 @@
+FROM python:3.13.13-slim-bookworm
+
+# Custom CA cert (社内証明書対応)
+COPY docker/certs/nscacert.pem /usr/local/share/ca-certificates/nscacert.crt
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    update-ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends \
+        nodejs \
+        make \
+        jq \
+        openssh-client \
+        zip \
+        unzip \
+        tree \
+        procps \
+        iproute2 \
+        iputils-ping && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# uv (バージョンを本番 Dockerfile と揃える)
+COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /usr/local/bin/
+
+ENV UV_CACHE_DIR=/opt/uv-cache \
+    UV_LINK_MODE=copy \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/nscacert.crt
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+RUN groupadd --gid ${USER_GID} ${USERNAME} && \
+    useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} && \
+    mkdir -p /opt/uv-cache && \
+    chown ${USERNAME}:${USERNAME} /opt/uv-cache && \
+    # Anonymous volume の初期化オーナーを vscode に設定する
+    # Docker はイメージ内のパスのオーナー情報を使って anonymous volume を初期化するため、
+    # これらのディレクトリを vscode 所有で作成しておく必要がある。
+    # 未設定の場合 root:root で初期化され postCreateCommand の uv sync / npm install が失敗する。
+    mkdir -p /workspace/.venv /workspace/frontend/node_modules && \
+    chown -R ${USERNAME}:${USERNAME} /workspace
+
+USER ${USERNAME}

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,75 @@
+# Dev Container セットアップ
+
+## 前提条件
+
+- Docker Desktop（WSL2 バックエンド有効）
+- VSCode 拡張: [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)、[Remote - WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl)
+- WSL2 上の Linux ディストリビューション（Ubuntu 推奨）
+
+## セットアップ手順
+
+### 1. リポジトリを WSL2 上にクローンする
+
+**Windows の `C:\` 配下ではなく、WSL2 の Linux ファイルシステム上にクローンしてください。**
+Windows 側にクローンするとファイルシステムの性質上、大幅な性能劣化が発生します。
+
+```bash
+# WSL2 ターミナル上で実行
+cd ~
+git clone <repository-url> koiki-pyfw
+cd koiki-pyfw
+```
+
+### 2. 社内 CA 証明書を配置する
+
+`docker/certs/nscacert.pem` に証明書ファイルを配置してください。
+
+> **配置方法はプロジェクト Wiki を参照してください。**
+> 証明書が配置されていない場合、イメージビルドが失敗します。
+
+### 3. VSCode で開く
+
+```bash
+# WSL2 ターミナル上で実行
+code .
+```
+
+VSCode が起動したら、右下の通知または コマンドパレット（`Ctrl+Shift+P`）から
+**「Dev Containers: Reopen in Container」** を実行してください。
+
+初回はイメージのビルドと依存関係のインストールが行われます（数分かかる場合があります）。
+
+## 起動後の操作
+
+コンテナ起動時に DB マイグレーションが自動実行されます。
+
+| 操作 | VSCode タスク |
+|------|--------------|
+| バックエンド起動（FastAPI） | `Start Backend` |
+| フロントエンド起動（Next.js） | `Start Frontend` |
+| 両方同時起動 | `Start All` |
+| DB マイグレーション（手動） | `DB Migration (upgrade head)` |
+
+タスクはコマンドパレットから「Tasks: Run Task」で実行できます。
+
+ポートは自動転送されます。
+
+| ポート | 用途 |
+|--------|------|
+| 8000 | FastAPI バックエンド |
+| 3000 | Next.js フロントエンド |
+| 5432 | PostgreSQL |
+
+## Keycloak（オプション）
+
+SSO 機能が必要なプロジェクトでのみ使用します。通常起動では含まれません。
+
+```bash
+docker compose -f .devcontainer/docker-compose.devcontainer.yml --profile keycloak up
+```
+
+## Windows ネイティブでの開発（代替）
+
+Dev Container を使わず Windows 上で直接開発することも可能です。
+その場合は `.vscode/settings.json` の設定が適用されます。
+ただし、パフォーマンスおよび環境の一貫性の観点から **Dev Container（WSL2）を推奨します**。

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,9 @@
 {
   "name": "KOIKI-FW Dev",
-  "dockerComposeFile": [
-    "../docker-compose.yml",
-    "../docker-compose.dev.yml",
-    "docker-compose.devcontainer.yml"
-  ],
-  "service": "app",
-  "workspaceFolder": "/app",
-  "remoteUser": "appuser",
+  "dockerComposeFile": "docker-compose.devcontainer.yml",
+  "service": "workspace",
+  "workspaceFolder": "/workspace",
+  "remoteUser": "vscode",
 
   "features": {
     "ghcr.io/devcontainers/features/git:1": {}
@@ -16,22 +12,27 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        // Python / Backend
         "ms-python.python",
         "ms-python.pylance",
         "ms-python.black-formatter",
         "ms-python.isort",
         "charliermarsh.ruff",
-        "littlefoxteam.vscode-python-test-adapter",
+        // Frontend
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        // Git / Docker
         "ms-azuretools.vscode-docker",
         "donjayamanne.githistory",
         "eamodio.gitlens"
       ],
       "settings": {
-        "python.defaultInterpreterPath": "/app/.venv/bin/python",
+        "python.defaultInterpreterPath": "/workspace/.venv/bin/python",
         "python.analysis.extraPaths": [
-          "/app/app",
-          "/app/components/libkoiki/src",
-          "/app/components/koiki_ref_app/src"
+          "/workspace/app",
+          "/workspace/components/libkoiki/src",
+          "/workspace/components/koiki_ref_app/src"
         ],
         "python.terminal.activateEnvironment": false,
         "python.linting.enabled": false,
@@ -68,6 +69,20 @@
 
   "shutdownAction": "stopCompose",
 
-  "postCreateCommand": "[ -f /app/.env ] || cp /app/.env.example /app/.env && cd /app/components/koiki_ref_app && uv run alembic upgrade head",
-  "postStartCommand": "echo 'Dev container ready. Run: uvicorn koiki_ref_app.asgi:app --host 0.0.0.0 --port 8000 --reload'"
+  // 1. .env がなければ .env.example からコピー
+  // 2. Python 依存関係インストール (uv workspace メンバーを editable インストール)
+  // 3. フロントエンド依存関係インストール
+  // 4. DB マイグレーション適用 (失敗しても非致命的: postStartCommand でリトライする)
+  //
+  // 注意: /workspace/.venv と /workspace/frontend/node_modules は docker-compose.devcontainer.yml の
+  // anonymous volume で遮蔽されており、Dockerfile.devcontainer で vscode:vscode 所有にした
+  // ディレクトリとして初期化される（その修正が適用されたイメージを使用すること）。
+  // DB 接続先 "db" は Docker ネットワーク内のホスト名。alembic は DATABASE_URL が
+  // カレントディレクトリの .env から読まれるため /workspace から実行する。
+  "postCreateCommand": "git config --global --add safe.directory /workspace && [ -f /workspace/.env ] || cp /workspace/.env.example /workspace/.env && cd /workspace && uv sync --locked --group dev --group test && npm --prefix /workspace/frontend install",
+
+  // コンテナ起動のたびに DB マイグレーションを適用する。
+  // postCreateCommand でのトランジェントエラー (Hyper-V ソケットタイムアウト等) から自動回復する。
+  // alembic は idempotent なので重複適用しても安全。
+  "postStartCommand": "git config --global --add safe.directory /workspace && DATABASE_URL=postgresql+asyncpg://koiki_user:koiki_password@db:5432/koiki_todo_db uv run --directory /workspace alembic -c components/koiki_ref_app/alembic.ini upgrade head"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -72,17 +72,15 @@
   // 1. .env がなければ .env.example からコピー
   // 2. Python 依存関係インストール (uv workspace メンバーを editable インストール)
   // 3. フロントエンド依存関係インストール
-  // 4. DB マイグレーション適用 (失敗しても非致命的: postStartCommand でリトライする)
   //
   // 注意: /workspace/.venv と /workspace/frontend/node_modules は docker-compose.devcontainer.yml の
   // anonymous volume で遮蔽されており、Dockerfile.devcontainer で vscode:vscode 所有にした
   // ディレクトリとして初期化される（その修正が適用されたイメージを使用すること）。
-  // DB 接続先 "db" は Docker ネットワーク内のホスト名。alembic は DATABASE_URL が
-  // カレントディレクトリの .env から読まれるため /workspace から実行する。
   "postCreateCommand": "git config --global --add safe.directory /workspace && [ -f /workspace/.env ] || cp /workspace/.env.example /workspace/.env && cd /workspace && uv sync --locked --group dev --group test && npm --prefix /workspace/frontend install",
 
   // コンテナ起動のたびに DB マイグレーションを適用する。
-  // postCreateCommand でのトランジェントエラー (Hyper-V ソケットタイムアウト等) から自動回復する。
-  // alembic は idempotent なので重複適用しても安全。
-  "postStartCommand": "git config --global --add safe.directory /workspace && DATABASE_URL=postgresql+asyncpg://koiki_user:koiki_password@db:5432/koiki_todo_db uv run --directory /workspace alembic -c components/koiki_ref_app/alembic.ini upgrade head"
+  // DB 接続先 "db" は Docker ネットワーク内のホスト名。接続設定は環境変数で上書きできる。
+  // DB 接続を最大 60 秒待機し、一時的な接続失敗に備えて Alembic を最大 3 回実行する。
+  // 恒久的なマイグレーションエラーは最終試行後に非ゼロで終了する。
+  "postStartCommand": "git config --global --add safe.directory /workspace && /bin/sh /workspace/.devcontainer/scripts/post-start.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,73 @@
+{
+  "name": "KOIKI-FW Dev",
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "../docker-compose.dev.yml",
+    "docker-compose.devcontainer.yml"
+  ],
+  "service": "app",
+  "workspaceFolder": "/app",
+  "remoteUser": "appuser",
+
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.pylance",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "charliermarsh.ruff",
+        "littlefoxteam.vscode-python-test-adapter",
+        "ms-azuretools.vscode-docker",
+        "donjayamanne.githistory",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/app/.venv/bin/python",
+        "python.analysis.extraPaths": [
+          "/app/app",
+          "/app/components/libkoiki/src",
+          "/app/components/koiki_ref_app/src"
+        ],
+        "python.terminal.activateEnvironment": false,
+        "python.linting.enabled": false,
+        "python.linting.pylintEnabled": false,
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "components/libkoiki/tests",
+          "tests/unit/agent_guidance",
+          "components/koiki_ref_app/tests",
+          "tests/integration/services",
+          "-m",
+          "not db_integration"
+        ],
+        "editor.formatOnSave": true,
+        "[python]": {
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "ms-python.black-formatter",
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+
+  "forwardPorts": [8000, 3000, 5432, 8090],
+  "portsAttributes": {
+    "8000": { "label": "FastAPI Backend" },
+    "3000": { "label": "Next.js Frontend" },
+    "5432": { "label": "PostgreSQL" },
+    "8090": { "label": "Keycloak" }
+  },
+
+  "shutdownAction": "stopCompose",
+
+  "postCreateCommand": "[ -f /app/.env ] || cp /app/.env.example /app/.env && cd /app/components/koiki_ref_app && uv run alembic upgrade head",
+  "postStartCommand": "echo 'Dev container ready. Run: uvicorn koiki_ref_app.asgi:app --host 0.0.0.0 --port 8000 --reload'"
+}

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,18 +1,77 @@
+name: koiki_devcontainer
+
 services:
-  app:
-    # VS Code が接続している間コンテナを維持する (uvicorn は手動または Run/Debug で起動)
-    command: sleep infinity
-    # devcontainer では DB/Keycloak の起動を待たず app に即接続できるようにする
-    depends_on: {}
+  workspace:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile.devcontainer
     volumes:
-      # リポルート全体を /app にマウント (.git / .env / pyproject.toml 等を可視化)
-      - .:/app:cached
-      # Windows の .venv が Linux コンテナに見えてしまうのを anonymous volume で遮蔽
-      - /app/.venv
-      # uv キャッシュをコンテナ内に保持 (再ビルド高速化)
+      # リポジトリ全体を /workspace にマウント
+      - ..:/workspace:cached
+      # Windows の .venv / node_modules が Linux コンテナに見えないよう anonymous volume で遮蔽
+      - /workspace/.venv
+      - /workspace/frontend/node_modules
+      # uv キャッシュをコンテナ内に保持（再ビルド高速化）
       - uv_cache:/opt/uv-cache
+    command: sleep infinity
     environment:
       - APP_ENV=development
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - koiki_dev
+
+  db:
+    image: postgres:15
+    # .env.example のデフォルト値に合わせた初期設定
+    environment:
+      POSTGRES_USER: koiki_user
+      POSTGRES_PASSWORD: koiki_password
+      POSTGRES_DB: koiki_todo_db
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U koiki_user -d koiki_todo_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    command:
+      - "postgres"
+      - "-c"
+      - "max_connections=100"
+      - "-c"
+      - "shared_buffers=256MB"
+    networks:
+      - koiki_dev
+
+  # profiles: [keycloak] により、通常起動では含まれない
+  # 起動する場合: docker compose --profile keycloak up
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.3.5
+    profiles: [keycloak]
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+      KC_METRICS_ENABLED: "true"
+    volumes:
+      - ../docker/keycloak/realm-koiki.json:/opt/keycloak/data/import/realm-koiki.json:ro
+      - ../docker/keycloak/realm-saml.json:/opt/keycloak/data/import/realm-saml.json:ro
+      - keycloak_data:/opt/keycloak/data
+    ports:
+      - "8090:8080"
+      - "9000:9000"
+    networks:
+      - koiki_dev
 
 volumes:
+  postgres_data:
+  keycloak_data:
   uv_cache:
+
+networks:
+  koiki_dev:

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,18 @@
+services:
+  app:
+    # VS Code が接続している間コンテナを維持する (uvicorn は手動または Run/Debug で起動)
+    command: sleep infinity
+    # devcontainer では DB/Keycloak の起動を待たず app に即接続できるようにする
+    depends_on: {}
+    volumes:
+      # リポルート全体を /app にマウント (.git / .env / pyproject.toml 等を可視化)
+      - .:/app:cached
+      # Windows の .venv が Linux コンテナに見えてしまうのを anonymous volume で遮蔽
+      - /app/.venv
+      # uv キャッシュをコンテナ内に保持 (再ビルド高速化)
+      - uv_cache:/opt/uv-cache
+    environment:
+      - APP_ENV=development
+
+volumes:
+  uv_cache:

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -u
+
+DB_HOST="${DB_HOST:-db}"
+DB_PORT="${DB_PORT:-5432}"
+DB_WAIT_TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
+DB_WAIT_INTERVAL="${DB_WAIT_INTERVAL:-2}"
+MIGRATION_MAX_ATTEMPTS="${MIGRATION_MAX_ATTEMPTS:-3}"
+MIGRATION_RETRY_DELAY="${MIGRATION_RETRY_DELAY:-3}"
+DATABASE_URL="${DATABASE_URL:-postgresql+asyncpg://koiki_user:koiki_password@${DB_HOST}:${DB_PORT}/koiki_todo_db}"
+
+wait_for_db() {
+  deadline=$(( $(date +%s) + DB_WAIT_TIMEOUT ))
+  attempt=1
+
+  while ! python3 -c \
+    'import socket, sys; socket.create_connection((sys.argv[1], int(sys.argv[2])), 2).close()' \
+    "$DB_HOST" "$DB_PORT" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "ERROR: database ${DB_HOST}:${DB_PORT} is unreachable after ${DB_WAIT_TIMEOUT}s" >&2
+      return 1
+    fi
+
+    echo "Waiting for database ${DB_HOST}:${DB_PORT} (attempt ${attempt})..."
+    attempt=$((attempt + 1))
+    sleep "$DB_WAIT_INTERVAL"
+  done
+
+  echo "Database ${DB_HOST}:${DB_PORT} is reachable."
+}
+
+run_migrations() {
+  attempt=1
+
+  while [ "$attempt" -le "$MIGRATION_MAX_ATTEMPTS" ]; do
+    echo "Running database migrations (attempt ${attempt}/${MIGRATION_MAX_ATTEMPTS})..."
+
+    if DATABASE_URL="$DATABASE_URL" uv run --directory /workspace \
+      alembic -c components/koiki_ref_app/alembic.ini upgrade head; then
+      echo "Database migrations completed."
+      return 0
+    else
+      status=$?
+    fi
+
+    if [ "$attempt" -eq "$MIGRATION_MAX_ATTEMPTS" ]; then
+      echo "ERROR: database migrations failed after ${MIGRATION_MAX_ATTEMPTS} attempts" >&2
+      return "$status"
+    fi
+
+    echo "Migration attempt ${attempt} failed; retrying in ${MIGRATION_RETRY_DELAY}s..." >&2
+    attempt=$((attempt + 1))
+    sleep "$MIGRATION_RETRY_DELAY"
+  done
+}
+
+wait_for_db && run_migrations

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,56 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Start Backend",
+      "type": "shell",
+      "command": "uv run uvicorn koiki_ref_app.asgi:app --host 0.0.0.0 --port 8000 --reload",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev-servers"
+      },
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Start Frontend",
+      "type": "shell",
+      "command": "npm run dev -- --hostname 0.0.0.0 --port 3000",
+      "options": {
+        "cwd": "${workspaceFolder}/frontend"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev-servers"
+      },
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Start All",
+      "dependsOn": ["Start Backend", "Start Frontend"],
+      "dependsOrder": "parallel",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "DB Migration (upgrade head)",
+      "type": "shell",
+      "command": "uv run alembic upgrade head",
+      "options": {
+        "cwd": "${workspaceFolder}/components/koiki_ref_app"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      }
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,10 @@ FROM base AS dev
 RUN adduser --disabled-password --gecos "" appuser
 
 # Alembic versionsディレクトリの作成と所有者変更
-RUN mkdir -p /app/components/koiki_ref_app/alembic/versions && chown -R appuser:appuser /app
+# /opt/uv-cache も appuser に chown する (named volume がroot所有で初期化されるのを防ぐ)
+RUN mkdir -p /app/components/koiki_ref_app/alembic/versions \
+    && chown -R appuser:appuser /app \
+    && chown -R appuser:appuser /opt/uv-cache
 
 # 非rootユーザーに切り替え
 USER appuser

--- a/components/libkoiki/pyproject.toml
+++ b/components/libkoiki/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 # Enterprise-grade dependency management with strict versioning
 dependencies = [
     # Core Web Framework - Latest stable with security patches
-    "fastapi>=0.136.1,<0.137.0",          # Updated to allow Starlette security fixes
+    "fastapi>=0.136.3,<0.137.0",          # Updated to allow Starlette security fixes
+    "starlette>=1.1.0,<1.2.0",            # Direct dependency: middleware imports Starlette APIs directly
     "uvicorn>=0.34.3,<0.35.0",            # Updated ASGI server (major performance improvements)
     
     # Database Layer - Critical for data integrity

--- a/docs/dev/starlette-fastapi-security-update-plan.ja.md
+++ b/docs/dev/starlette-fastapi-security-update-plan.ja.md
@@ -316,3 +316,77 @@ uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests 
 - `HTTP_422_UNPROCESSABLE_ENTITY` deprecation warning
 
 いずれも今回の Starlette / FastAPI 更新で新規に発生した失敗ではない。
+
+## 12. 残件脆弱性対応結果
+
+実施日: 2026-05-28
+
+`Starlette / FastAPI` 更新後に残っていた `pip-audit` 検出を、lockfile 更新で解消した。
+
+実施内容:
+
+- `idna 3.13 -> 3.16`
+- `mako 1.3.11 -> 1.3.12`
+- `pip 26.0.1 -> 26.1.1`
+- `python-multipart 0.0.26 -> 0.0.29`
+- `urllib3 2.6.3 -> 2.7.0`
+
+依存元分類:
+
+- `python-multipart`: root direct runtime dependency
+- `idna`: `anyio` / `httpx` / `email-validator` / `requests` 経由
+- `mako`: `alembic` 経由
+- `urllib3`: `requests` 経由。主に `pip-audit` / `cachecontrol` 側
+- `pip`: `pip-audit` / `pip-api` 側
+
+解決確認:
+
+```text
+uv lock --upgrade-package idna --upgrade-package mako --upgrade-package python-multipart --upgrade-package urllib3 --upgrade-package pip
+  Updated idna v3.13 -> v3.16
+  Updated mako v1.3.11 -> v1.3.12
+  Updated pip v26.0.1 -> v26.1.1
+  Updated python-multipart v0.0.26 -> v0.0.29
+  Updated urllib3 v2.6.3 -> v2.7.0
+
+uv lock --check
+  Resolved 85 packages
+
+uv run --locked python -c "import importlib.metadata as m; ..."
+  idna 3.16
+  mako 1.3.12
+  pip 26.1.1
+  python-multipart 0.0.29
+  urllib3 2.7.0
+```
+
+監査結果:
+
+```text
+uv run --locked pip-audit
+  No known vulnerabilities found
+
+Name          Skip Reason
+------------- ----------------------------------------------------------------------------
+koiki-ref-app Dependency not found on PyPI and could not be audited: koiki-ref-app (0.7.0)
+libkoiki      Dependency not found on PyPI and could not be audited: libkoiki (0.7.0)
+```
+
+検証結果:
+
+```text
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py components/koiki_ref_app/tests/unit/app/test_saml_auth_logging.py
+  35 passed
+
+uv run --locked pytest components/libkoiki/tests/unit/libkoiki/api/test_auth_logging.py
+  7 passed
+
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/test_sso_auth_logging.py
+  16 passed
+
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+  204 passed, 1 skipped, 11 deselected
+```
+
+既知 warning は 11 章と同じ。
+今回の残件脆弱性対応で新規の test failure は確認されていない。

--- a/docs/dev/starlette-fastapi-security-update-plan.ja.md
+++ b/docs/dev/starlette-fastapi-security-update-plan.ja.md
@@ -1,0 +1,318 @@
+# Starlette / FastAPI セキュリティ依存更新計画
+
+作成日: 2026-05-28
+
+関連:
+
+- `docs/dev/dm08-dm10-security-task-plan.ja.md`
+- `docs/dev/deferred-maintenance-tasks.ja.md`
+- `docs/security/SECURITY_AUDIT_COMMANDS.md`
+- `pyproject.toml`
+- `components/libkoiki/pyproject.toml`
+
+## 1. 目的
+
+`pip-audit` で検出された `starlette 0.52.1 / PYSEC-2026-161` を解消するため、Starlette を `1.1.0` へ更新する。
+
+あわせて FastAPI は `0.136.3` を前提に更新する。
+
+今回の主目的は Starlette の脆弱性解消であり、Prometheus 連携は現状 optional として扱う。
+
+## 2. 現状
+
+監査結果:
+
+```text
+starlette 0.52.1 PYSEC-2026-161 1.0.1
+```
+
+確認済みの依存関係:
+
+- `fastapi==0.136.3` は `starlette>=0.46.0` を要求し、Starlette 1.1.0 と依存制約上は両立する。
+- `starlette==1.1.0` は Python `>=3.10` を要求し、本プロジェクトの `>=3.11.7,<4.0` と両立する。
+- `prometheus-fastapi-instrumentator==7.1.0` は `starlette<1.0.0,>=0.30.0` を要求するため、Starlette 1.1.0 と両立しない。
+- 2026-05-28 時点で `prometheus-fastapi-instrumentator` の PyPI 最新は `7.1.0` であり、Starlette 1.x 対応版は未確認。
+
+コード確認結果:
+
+- `components/libkoiki/src/libkoiki/core/monitoring.py` は `prometheus_fastapi_instrumentator` / `prometheus_client` の import 失敗時に dummy 実装へ fallback する。
+- `components/koiki_ref_app/src/koiki_ref_app/app_factory.py` は `setup_monitoring` を import しているが、現状 `create_app()` 内で呼び出していない。
+- Prometheus package 不在を模擬した import と `setup_monitoring(app)` 実行は成功し、`/metrics` が登録されないだけで runtime error にはならない。
+
+## 3. 方針
+
+Starlette 1.1.0 を優先する。
+
+そのため、短期対応として `prometheus-fastapi-instrumentator` を direct dependency から外す。
+
+理由:
+
+- `PYSEC-2026-161` は runtime web framework 側の脆弱性であり、優先度が高い。
+- 現状の Prometheus 連携は app startup で有効化されていない。
+- `monitoring.py` に package 不在時の fallback が実装済みである。
+- `prometheus-fastapi-instrumentator` の現行最新版は Starlette 1.x と依存制約上衝突する。
+
+## 4. 変更対象
+
+### root dependency
+
+`pyproject.toml`:
+
+- `fastapi>=0.136.1,<0.137.0` を `fastapi>=0.136.3,<0.137.0` へ更新する。
+- `starlette>=1.1.0,<1.2.0` を direct dependency として追加する。
+- `prometheus-fastapi-instrumentator>=7.1.0,<7.2.0` を削除する。
+
+### libkoiki dependency
+
+`components/libkoiki/pyproject.toml`:
+
+- `fastapi>=0.136.1,<0.137.0` を `fastapi>=0.136.3,<0.137.0` へ更新する。
+- `starlette>=1.1.0,<1.2.0` を direct dependency として追加する。
+
+理由:
+
+- `components/libkoiki/src/libkoiki/core/middleware.py` は `starlette.middleware.base` / `starlette.responses` / `starlette.types` を直接 import している。
+- Starlette は FastAPI の transitive dependency ではなく、`libkoiki` の direct dependency として明示するのが妥当である。
+
+### lockfile
+
+`uv.lock`:
+
+- `fastapi` を `0.136.3` へ更新する。
+- `starlette` を `1.1.0` へ更新する。
+- `prometheus-fastapi-instrumentator` が不要になっていることを確認する。
+- `prometheus-client` が他の direct/transitive dependency から必要か確認する。
+
+## 5. 実施手順
+
+1. 変更前の監査結果を保存する。
+
+```powershell
+uv run --locked pip-audit --format=json --output=pip-audit-starlette-before.json
+uv run --locked pip-audit
+uv tree
+```
+
+2. `pyproject.toml` と `components/libkoiki/pyproject.toml` を更新する。
+
+3. lockfile を更新する。
+
+```powershell
+uv lock --upgrade-package fastapi --upgrade-package starlette
+uv sync --locked --group dev --group test --group security
+uv lock --check
+```
+
+4. 解決後のバージョンを確認する。
+
+```powershell
+uv run --locked python -c "import fastapi, starlette; print(fastapi.__version__, starlette.__version__)"
+uv tree | Select-String -Pattern "fastapi|starlette|prometheus"
+```
+
+期待値:
+
+```text
+fastapi 0.136.3
+starlette 1.1.0
+```
+
+5. 変更後の監査結果を取得する。
+
+```powershell
+uv run --locked pip-audit --format=json --output=pip-audit-starlette-after.json
+uv run --locked pip-audit
+```
+
+## 6. 検証範囲
+
+### 最小確認
+
+```powershell
+$env:DEBUG='False'
+uv lock --check
+uv run --locked python -c "from koiki_ref_app.asgi import app; print(app.version)"
+uv run --locked pytest components/libkoiki/tests/unit/core/test_audit_middleware.py
+```
+
+### FastAPI / Starlette 回帰確認
+
+```powershell
+$env:DEBUG='False'
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+```
+
+### auth / SSO / SAML 重点確認
+
+```powershell
+$env:DEBUG='False'
+uv run --locked pytest components/koiki_ref_app/tests/integration/app/api/test_auth_api.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_sso_service.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/test_sso_auth_logging.py
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/test_saml_auth_logging.py
+```
+
+### Prometheus optional fallback 確認
+
+`prometheus-fastapi-instrumentator` を外した後、次が失敗しないことを確認する。
+
+```powershell
+$env:DEBUG='False'
+uv run --locked python -c "from libkoiki.core.monitoring import PROMETHEUS_AVAILABLE, increment_user_registration; print(PROMETHEUS_AVAILABLE); increment_user_registration(); print('ok')"
+uv run --locked python -c "from fastapi import FastAPI; from libkoiki.core.monitoring import setup_monitoring; app=FastAPI(); setup_monitoring(app); print([r.path for r in app.routes])"
+```
+
+期待値:
+
+- `PROMETHEUS_AVAILABLE` は `False`
+- import / counter increment / `setup_monitoring(app)` は成功する
+- `/metrics` は登録されない
+
+## 7. 完了条件
+
+- `fastapi` が `0.136.3` に更新されている。
+- `starlette` が `1.1.0` に更新されている。
+- `prometheus-fastapi-instrumentator` が runtime dependency から外れている。
+- `uv lock --check` が成功する。
+- `PYSEC-2026-161` が `pip-audit` 結果から消えている。
+- Prometheus package 不在時も `libkoiki.core.monitoring` の import と fallback が機能する。
+- middleware / auth / SSO / SAML の主要テストが通っている。
+
+## 8. 残件の扱い
+
+Starlette 更新後も、監査結果には他 package の検出が残る可能性がある。
+
+現時点の既知候補:
+
+- `idna 3.13 -> 3.15`
+- `mako 1.3.11 -> 1.3.12`
+- `pip 26.0.1 -> 26.1`
+- `python-multipart 0.0.26 -> 0.0.27`
+- `urllib3 2.6.3 -> 2.7.0`
+
+今回の PR で扱うかは、Starlette / FastAPI 更新の差分が安定した後に判断する。
+
+原則:
+
+- Starlette 脆弱性解消を最優先にする。
+- 追加更新が lockfile のみで済み、回帰範囲が広がらないものは同時対応を検討する。
+- FastAPI / Starlette と無関係な残件は、別 PR または別タスクとして記録してもよい。
+- `pip` は runtime dependency か、監査実行環境側 dependency かを切り分けて記録する。
+
+## 9. 後続判断
+
+### Prometheus 連携
+
+`prometheus-fastapi-instrumentator` の Starlette 1.x 対応版が公開されたら、再導入を検討する。
+
+再導入時の条件:
+
+- Starlette 1.x と依存制約上両立する。
+- `setup_monitoring(app)` を有効化するかどうかを明示する。
+- `/metrics` endpoint の公開要否、OpenAPI schema への含有要否、production exposure policy を決める。
+- monitoring endpoint のテストを追加する。
+
+### 代替 monitoring
+
+`prometheus-fastapi-instrumentator` の対応が遅い場合は、次を比較する。
+
+- `prometheus_client` 直利用
+- ASGI middleware 自作
+- OpenTelemetry metrics への移行
+
+この判断は Starlette 脆弱性対応 PR には含めない。
+
+## 10. 注意事項
+
+- `components/libkoiki/` の reusable framework behavior と `components/koiki_ref_app/` の reference app composition を混ぜない。
+- Prometheus 連携を外す変更は、monitoring capability の削除ではなく、Starlette 1.x 非対応 package の一時除外として扱う。
+- `setup_monitoring(app)` を新たに有効化しない。
+- root `app/` は compatibility wrapper として扱い、新規実装を追加しない。
+- Codex 環境では `DEBUG=release` が混入する場合があるため、検証時は `DEBUG=True` または `DEBUG=False` を明示する。
+
+## 11. 実施結果
+
+実施日: 2026-05-28
+
+実施内容:
+
+- `pyproject.toml`
+  - `fastapi>=0.136.3,<0.137.0` へ更新した。
+  - `starlette>=1.1.0,<1.2.0` を direct dependency として追加した。
+  - `prometheus-fastapi-instrumentator>=7.1.0,<7.2.0` を削除した。
+- `components/libkoiki/pyproject.toml`
+  - `fastapi>=0.136.3,<0.137.0` へ更新した。
+  - `starlette>=1.1.0,<1.2.0` を direct dependency として追加した。
+- `uv.lock`
+  - `fastapi 0.136.1 -> 0.136.3`
+  - `starlette 0.52.1 -> 1.1.0`
+  - `prometheus-fastapi-instrumentator 7.1.0` を削除
+  - `prometheus-client 0.25.0` を削除
+
+解決確認:
+
+```text
+uv lock --check
+  Resolved 85 packages
+
+uv run --locked python -c "import fastapi, starlette; print(fastapi.__version__, starlette.__version__)"
+  0.136.3 1.1.0
+```
+
+Prometheus optional fallback 確認:
+
+```text
+from libkoiki.core.monitoring import PROMETHEUS_AVAILABLE, increment_user_registration
+  PROMETHEUS_AVAILABLE=False
+  increment_user_registration() 成功
+
+setup_monitoring(FastAPI()) 実行
+  Prometheus monitoring disabled - package not installed
+  /metrics は登録されない
+```
+
+`pip-audit` 結果:
+
+```text
+Found 7 known vulnerabilities in 5 packages
+
+idna             3.13    CVE-2026-45409 3.15
+mako             1.3.11  CVE-2026-44307 1.3.12
+pip              26.0.1  CVE-2026-3219  26.1
+pip              26.0.1  CVE-2026-6357  26.1
+python-multipart 0.0.26  CVE-2026-42561 0.0.27
+urllib3          2.6.3   PYSEC-2026-142 2.7.0
+urllib3          2.6.3   PYSEC-2026-141 2.7.0
+```
+
+`starlette / PYSEC-2026-161` は検出結果から消えた。
+
+検証結果:
+
+```text
+uv run --locked python -c "from koiki_ref_app.asgi import app; print(app.version)"
+  0.7.0
+
+uv run --locked pytest components/libkoiki/tests/unit/core/test_audit_middleware.py
+  6 passed
+
+uv run --locked pytest components/koiki_ref_app/tests/integration/app/api/test_auth_api.py
+  11 skipped
+
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_sso_service.py components/koiki_ref_app/tests/unit/app/test_sso_auth_logging.py
+  16 passed
+
+uv run --locked pytest components/koiki_ref_app/tests/unit/app/services/test_saml_service.py components/koiki_ref_app/tests/unit/app/test_saml_auth_logging.py
+  35 passed
+
+uv run --locked pytest components/libkoiki/tests components/koiki_ref_app/tests -m "not db_integration"
+  204 passed, 1 skipped, 11 deselected
+```
+
+既知 warning:
+
+- `components/libkoiki/src/libkoiki/core/transaction.py` と `AsyncMock` の組み合わせによる既存 `RuntimeWarning`
+- `HTTP_422_UNPROCESSABLE_ENTITY` deprecation warning
+
+いずれも今回の Starlette / FastAPI 更新で新規に発生した失敗ではない。

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -33,6 +33,32 @@ RUN if [ "${FRONTEND_ENV_FILE}" != ".env.production" ] && [ "${FRONTEND_ENV_FILE
 RUN npm run build
 
 # ---------------------
+# Development stage
+# ---------------------
+FROM node:22-slim AS dev
+
+COPY docker/certs/nscacert.pem /usr/local/share/ca-certificates/nscacert.crt
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates wget curl && \
+  update-ca-certificates && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/nscacert.crt \
+  SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+  NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]
+
+# ---------------------
 # Runtime stage
 # ---------------------
 FROM node:22-slim AS runner

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "dev:turbo": "next dev --turbopack",
+    "dev": "next dev --port 3000",
+    "dev:turbo": "next dev --turbopack --port 3000",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 # All runtime dependencies with strict version control for production stability
 dependencies = [
     # Core Web Framework
-    "fastapi>=0.136.1,<0.137.0",            # Updated to allow Starlette security fixes
+    "fastapi>=0.136.3,<0.137.0",            # Updated to allow Starlette security fixes
+    "starlette>=1.1.0,<1.2.0",              # Direct dependency: libkoiki imports Starlette APIs directly
     "uvicorn>=0.34.3,<0.35.0",              # Updated ASGI server (major performance improvements)
     
     # Database Layer (Python 3.13 compatible)
@@ -54,7 +55,6 @@ dependencies = [
     
     # Logging & Monitoring
     "structlog>=25.4.0,<25.5.0",            # Updated structured logging
-    "prometheus-fastapi-instrumentator>=7.1.0,<7.2.0", # Updated monitoring instrumentation
     
     # Caching & Performance
     "redis>=6.2.0,<6.3.0",                  # Updated Redis client (major version)

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "eb0e91e84277283dc2b23ed544399e53afd6b5287e5b6929f25fe8aa608e164b"
+    }
+  }
+}

--- a/tests/unit/agent_guidance/test_skill_catalog.py
+++ b/tests/unit/agent_guidance/test_skill_catalog.py
@@ -24,7 +24,7 @@ def _parse_frontmatter(skill_path: Path) -> dict[str, str]:
 
 def test_canonical_and_claude_skill_sets_match() -> None:
     canonical = {path.name for path in _skill_directories(CANONICAL_ROOT)}
-    wrappers = {path.name for path in _skill_directories(CLAUDE_ROOT)}
+    wrappers = {path.name for path in _skill_directories(CLAUDE_ROOT) if path.name.startswith("koiki-")}
 
     assert canonical, "canonical skill directories must exist"
     assert canonical == wrappers
@@ -84,6 +84,8 @@ def test_openai_metadata_tracks_api_ownership_routing_terms() -> None:
 
 def test_claude_wrappers_point_to_canonical_skills() -> None:
     for wrapper_dir in _skill_directories(CLAUDE_ROOT):
+        if not wrapper_dir.name.startswith("koiki-"):
+            continue
         wrapper_path = wrapper_dir / "SKILL.md"
         assert wrapper_path.exists(), f"{wrapper_dir.name} wrapper is missing SKILL.md"
 

--- a/uv.lock
+++ b/uv.lock
@@ -721,11 +721,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -1048,14 +1048,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -1226,11 +1226,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]
@@ -1562,11 +1562,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -1880,11 +1880,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.1"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -611,9 +611,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -762,7 +762,6 @@ dependencies = [
     { name = "koiki-ref-app" },
     { name = "libkoiki" },
     { name = "limits" },
-    { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -772,6 +771,7 @@ dependencies = [
     { name = "redis" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "starlette" },
     { name = "structlog" },
     { name = "tzdata" },
     { name = "uvicorn" },
@@ -807,12 +807,11 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
     { name = "bcrypt", specifier = ">=4.3.0,<5.0.0" },
     { name = "email-validator", specifier = ">=2.2.0,<2.3.0" },
-    { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
+    { name = "fastapi", specifier = ">=0.136.3,<0.137.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "koiki-ref-app", editable = "components/koiki_ref_app" },
     { name = "libkoiki", editable = "components/libkoiki" },
     { name = "limits", specifier = ">=5.4.0,<5.5.0" },
-    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0,<7.2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9,<2.10.0" },
     { name = "pydantic", specifier = ">=2.11.7,<2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.10.0,<2.11.0" },
@@ -822,6 +821,7 @@ requires-dist = [
     { name = "redis", specifier = ">=6.2.0,<6.3.0" },
     { name = "slowapi", specifier = ">=0.1.8,<0.2.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.23,<2.1.0" },
+    { name = "starlette", specifier = ">=1.1.0,<1.2.0" },
     { name = "structlog", specifier = ">=25.4.0,<25.5.0" },
     { name = "tzdata", specifier = ">=2024.2,<2026.0" },
     { name = "uvicorn", specifier = ">=0.34.3,<0.35.0" },
@@ -880,6 +880,7 @@ dependencies = [
     { name = "redis" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "starlette" },
     { name = "structlog" },
     { name = "tzdata" },
     { name = "uvicorn" },
@@ -898,7 +899,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.16.2,<1.17.0" },
     { name = "asyncpg", specifier = ">=0.30.0,<0.31.0" },
     { name = "bcrypt", specifier = ">=4.3.0,<5.0.0" },
-    { name = "fastapi", specifier = ">=0.136.1,<0.137.0" },
+    { name = "fastapi", specifier = ">=0.136.3,<0.137.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },
     { name = "pydantic", specifier = ">=2.11.7,<2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.10.0,<2.11.0" },
@@ -910,6 +911,7 @@ requires-dist = [
     { name = "redis", specifier = ">=6.2.0,<6.3.0" },
     { name = "slowapi", specifier = ">=0.1.8,<0.2.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.23,<2.1.0" },
+    { name = "starlette", specifier = ">=1.1.0,<1.2.0" },
     { name = "structlog", specifier = ">=25.4.0,<25.5.0" },
     { name = "tzdata", specifier = ">=2024.2,<2026.0" },
     { name = "uvicorn", specifier = ">=0.34.3,<0.35.0" },
@@ -1293,28 +1295,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
-]
-
-[[package]]
-name = "prometheus-fastapi-instrumentator"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "prometheus-client" },
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
 ]
 
 [[package]]
@@ -1776,15 +1756,15 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

v0.7.0-post2 以降に dev/v0.7 へ蓄積した変更を main へ取り込む。
3つの独立した改善を含む：Dev Container 環境整備、grill-with-docs スキル追加、セキュリティ依存更新。

## 変更内容

### 1. Dev Container 環境整備 (#117 / #118)

- `.devcontainer/` を新規追加：Dockerfile・docker-compose・devcontainer.json 一式
- VS Code タスク (`.vscode/tasks.json`) でバックエンド・フロントエンド・DB マイグレーションの起動を統合
- `frontend/Dockerfile` を追加
- Dev Container のセットアップ手順 README を追加

### 2. grill-with-docs スキル追加

- `.claude/skills/grill-with-docs/` および `.agents/skills/grill-with-docs/` を追加
- プランを既存ドメインモデル・ADR に照合して設計を検証するスキル
- ADR・CONTEXT 文書のフォーマットテンプレートを同梱

### 3. セキュリティ依存更新 (#115)

- Starlette・FastAPI の脆弱性対応アップデート
- `components/libkoiki/pyproject.toml` および `pyproject.toml` の依存バージョンを更新
- `uv.lock` を同期

### 4. テスト修正

- `tests/unit/agent_guidance/test_skill_catalog.py`: Claude wrapper のスキャン対象を `koiki-` プレフィックス付きに限定（`grill-with-docs` が canonical セットに含まれない扱いを正しく維持）

## テスト確認

- `uv run --locked pytest tests/unit/agent_guidance/` が green であることを確認
- 依存更新後の動作確認済み

## 次のステップ

このマージ後、`main` から `dev/v0.7.1` を作成し、Agent Skills 命名整理（`koiki-app-feature-work` → `koiki-refapp-feature-work` リネーム＋ `koiki-business-app-feature-work` 新設）を実施予定。
