### PR TITLE
refactor(devcontainer): update frontend references from Next.js to Vi…

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -46,7 +46,7 @@ VSCode が起動したら、右下の通知または コマンドパレット（
 | 操作 | VSCode タスク |
 |------|--------------|
 | バックエンド起動（FastAPI） | `Start Backend` |
-| フロントエンド起動（Next.js） | `Start Frontend` |
+| フロントエンド起動（Vite React SPA） | `Start Frontend` |
 | 両方同時起動 | `Start All` |
 | DB マイグレーション（手動） | `DB Migration (upgrade head)` |
 
@@ -57,8 +57,11 @@ VSCode が起動したら、右下の通知または コマンドパレット（
 | ポート | 用途 |
 |--------|------|
 | 8000 | FastAPI バックエンド |
-| 3000 | Next.js フロントエンド |
+| 3000 | Vite React SPA 開発サーバー |
 | 5432 | PostgreSQL |
+
+Node.js はフロントエンド成果物のビルドと、必要に応じた Vite 開発サーバーの実行に使用します。
+Next.js のサーバーランタイムや BFF は使用しません。
 
 ## Keycloak（オプション）
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -62,7 +62,7 @@
   "forwardPorts": [8000, 3000, 5432, 8090],
   "portsAttributes": {
     "8000": { "label": "FastAPI Backend" },
-    "3000": { "label": "Next.js Frontend" },
+    "3000": { "label": "Vite React SPA Dev Server" },
     "5432": { "label": "PostgreSQL" },
     "8090": { "label": "Keycloak" }
   },
@@ -71,7 +71,7 @@
 
   // 1. .env がなければ .env.example からコピー
   // 2. Python 依存関係インストール (uv workspace メンバーを editable インストール)
-  // 3. フロントエンド依存関係インストール
+  // 3. React SPA のビルド・開発サーバー用 Node 依存関係をインストール
   //
   // 注意: /workspace/.venv と /workspace/frontend/node_modules は docker-compose.devcontainer.yml の
   // anonymous volume で遮蔽されており、Dockerfile.devcontainer で vscode:vscode 所有にした

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,7 +19,7 @@
     {
       "label": "Start Frontend",
       "type": "shell",
-      "command": "npm run dev -- --hostname 0.0.0.0 --port 3000",
+      "command": "npm run dev",
       "options": {
         "cwd": "${workspaceFolder}/frontend"
       },


### PR DESCRIPTION
## 概要

- Dev Container 関連のフロントエンド参照を Next.js から Vite React SPA に更新
- `dev/v0.7-react-only` の現在のフロントエンド構成に合わせて、開発環境の記述・設定を整理

## 背景

`wsl2-devcontainer-check` は `dev/v0.7-react-only` を元にしたブランチです。

React SPA 移行後の Dev Container 周辺に残っていた Next.js 前提の参照を、現在の Vite React SPA 構成に合わせるためのフォローアップです。

## 確認内容

- マージ先が `dev/v0.7-react-only` であることを確認
- この PR の差分が Dev Container 周辺のフロントエンド参照更新であることを確認