### PR TITLE
chore: バージョン番号を0.8.0へ更新

### DIFF
--- a/components/koiki_ref_app/pyproject.toml
+++ b/components/koiki_ref_app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koiki_ref_app"
-version = "0.7.1"
+version = "0.8.0"
 description = "Reference application built with KOIKI Framework."
 authors = [{ name = "KOIKI Team" }]
 license = {text = "MIT"}

--- a/components/koiki_ref_app/src/koiki_ref_app/app_factory.py
+++ b/components/koiki_ref_app/src/koiki_ref_app/app_factory.py
@@ -197,7 +197,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title=settings.APP_NAME,
         debug=settings.DEBUG,
-        version="0.7.1",
+        version="0.8.0",
         openapi_url="/openapi.json" if settings.APP_ENV != "production" else None,
         docs_url="/docs" if settings.APP_ENV != "production" else None,
         redoc_url="/redoc" if settings.APP_ENV != "production" else None,
@@ -242,7 +242,7 @@ def create_app() -> FastAPI:
         return {
             "status": "healthy",
             "service": "koiki-framework",
-            "version": "0.7.1",
+            "version": "0.8.0",
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -252,7 +252,7 @@ def create_app() -> FastAPI:
         logger.debug("Root endpoint called.")
         return {
             "service": "KOIKI Framework API",
-            "version": "0.7.1",
+            "version": "0.8.0",
             "docs": "/docs",
             "health": "/health",
         }

--- a/components/libkoiki/pyproject.toml
+++ b/components/libkoiki/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libkoiki"
-version = "0.7.1"
+version = "0.8.0"
 description = "Enterprise-grade FastAPI application framework."
 readme = "README.md"
 authors = [{ name = "KOIKI Team" }]

--- a/components/libkoiki/src/libkoiki/__init__.py
+++ b/components/libkoiki/src/libkoiki/__init__.py
@@ -5,4 +5,4 @@ This package provides enterprise features for FastAPI applications
 including security, logging, error handling, and more.
 """
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koiki-pyfw"
-version = "0.7.1"
+version = "0.8.0"
 description = "FastAPI enterprise application framework"
 readme = "README.md"
 requires-python = ">=3.11.7,<4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -748,7 +748,7 @@ wheels = [
 
 [[package]]
 name = "koiki-pyfw"
-version = "0.7.1"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -851,7 +851,7 @@ test = [
 
 [[package]]
 name = "koiki-ref-app"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "components/koiki_ref_app" }
 dependencies = [
     { name = "defusedxml" },
@@ -866,7 +866,7 @@ requires-dist = [
 
 [[package]]
 name = "libkoiki"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "components/libkoiki" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- root / libkoiki / koiki_ref_app の各 pyproject.toml を `0.7.1` → `0.8.0` に更新
- `components/libkoiki/src/libkoiki/__init__.py` の `__version__` を更新
- `app_factory.py` の FastAPI `version` と `/health` `/` 応答の `version` フィールド（計3箇所）を更新
- `uv.lock` を `uv lock` で再生成し、`uv lock --check` が通ることを確認
- `frontend/package.json` の `"0.1.0"` は backend バージョンと独立管理のため変更なし

## Test plan
- [x] `uv lock --check` が通ることを確認
- [x] `uv run pytest components/koiki_ref_app/tests/ -q` で 97 passed, 28 skipped を確認
- [ ] CI がグリーンであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)