### PR TITLE
docs: clarify no-capability-skip guidance in KOIKI spec authoring guidelines

### DIFF
--- a/docs/agent/skills/koiki-spec-authoring/SKILL.md
+++ b/docs/agent/skills/koiki-spec-authoring/SKILL.md
@@ -81,7 +81,7 @@ These break the artifact without producing a validation error.
 
 - do not write English SHALL prose (`The system SHALL ...`); this repository uses the 【SHALL】 label form
 - do not add `## Purpose` to a delta spec when the capability spec already exists — it is ignored
-- do not create a requirement just to satisfy validation; set `skip_specs: true` in the change's `.openspec.yaml` when no spec-level behavior changes
+- do not create a requirement just to satisfy validation. This repository's `spec-driven` schema has no capability-less path: `tasks` requires `specs`, and `specs` requires at least one capability. When a change looks non-business (cross-cutting, technical-only), look for the business domain it actually serves — audit, observability, and operational-monitoring concerns are legitimate capabilities in a regulated business, not just "infra" — and scope the Requirement narrowly to what the change implements. Do not invent a capability-skip mechanism; none exists in the installed `openspec` CLI
 - do not put 配下の実装Spec単位一覧 in the 機能Spec; SPEC-MAP.md owns it
 - do not put インデックス方針, 実装方式, or 技術選定の理由 in a spec file; they belong in `design.md`
 - do not leave a 制約条件 without a measurable scenario — if the measurement condition cannot be stated, the constraint belongs in `design.md`


### PR DESCRIPTION
## Summary
- `docs/agent/skills/koiki-spec-authoring/SKILL.md` のガードレール行を修正
- 存在しない `skip_specs: true`（`.openspec.yaml`）への言及を削除
- 代わりに、非業務・横断的な小変更でも業務ドメインのcapabilityを見つけて narrow scope で属させる方針を明記（`spec-driven` スキーマに capability無しの経路が存在しないため）

## Background
OPSX v1.6.0ワークフローの実地検証中に、SKILL.mdが参照する `skip_specs: true` が実際のCLI（インストール済み `@fission-ai/openspec` v1.6.0）の `.openspec.yaml` スキーマに存在しない（`schema`/`created`/`goal`/`affected_areas`/`initiative` のみサポート）ことを確認した。この記述に従うと `tasks` が永久にブロックされる誤った手順になるため訂正した。

## Test plan
- [x] ドキュメントのみの変更（コード変更なし）
- [x] 修正前後で `docs/agent/skills/koiki-spec-authoring/SKILL.md` の該当行のみ差分になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)