### PR TITLE
chore(release): bump version to 0.8.1

### DIFF
--- a/components/koiki_ref_app/pyproject.toml
+++ b/components/koiki_ref_app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koiki_ref_app"
-version = "0.8.0"
+version = "0.8.1"
 description = "Reference application built with KOIKI Framework."
 authors = [{ name = "KOIKI Team" }]
 license = {text = "MIT"}

--- a/components/koiki_ref_app/src/koiki_ref_app/app_factory.py
+++ b/components/koiki_ref_app/src/koiki_ref_app/app_factory.py
@@ -197,7 +197,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title=settings.APP_NAME,
         debug=settings.DEBUG,
-        version="0.8.0",
+        version="0.8.1",
         openapi_url="/openapi.json" if settings.APP_ENV != "production" else None,
         docs_url="/docs" if settings.APP_ENV != "production" else None,
         redoc_url="/redoc" if settings.APP_ENV != "production" else None,
@@ -242,7 +242,7 @@ def create_app() -> FastAPI:
         return {
             "status": "healthy",
             "service": "koiki-framework",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -252,7 +252,7 @@ def create_app() -> FastAPI:
         logger.debug("Root endpoint called.")
         return {
             "service": "KOIKI Framework API",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "docs": "/docs",
             "health": "/health",
         }

--- a/components/koiki_ref_app/tests/unit/app/test_app_version.py
+++ b/components/koiki_ref_app/tests/unit/app/test_app_version.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import asyncio
+
+from koiki_ref_app import app_factory
+
+
+def test_app_exposes_release_version_in_metadata_and_status_endpoints() -> None:
+    app = app_factory.create_app()
+    routes = {route.path: route for route in app.routes}
+
+    health = asyncio.run(routes["/health"].endpoint(None))
+    root = asyncio.run(routes["/"].endpoint(None))
+
+    assert app.version == "0.8.1"
+    assert app.openapi()["info"]["version"] == "0.8.1"
+    assert health["version"] == "0.8.1"
+    assert root["version"] == "0.8.1"

--- a/components/libkoiki/pyproject.toml
+++ b/components/libkoiki/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libkoiki"
-version = "0.8.0"
+version = "0.8.1"
 description = "Enterprise-grade FastAPI application framework."
 readme = "README.md"
 authors = [{ name = "KOIKI Team" }]

--- a/components/libkoiki/src/libkoiki/__init__.py
+++ b/components/libkoiki/src/libkoiki/__init__.py
@@ -5,4 +5,4 @@ This package provides enterprise features for FastAPI applications
 including security, logging, error handling, and more.
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koiki-pyfw"
-version = "0.8.0"
+version = "0.8.1"
 description = "FastAPI enterprise application framework"
 readme = "README.md"
 requires-python = ">=3.11.7,<4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -748,7 +748,7 @@ wheels = [
 
 [[package]]
 name = "koiki-pyfw"
-version = "0.8.0"
+version = "0.8.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -851,7 +851,7 @@ test = [
 
 [[package]]
 name = "koiki-ref-app"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "components/koiki_ref_app" }
 dependencies = [
     { name = "defusedxml" },
@@ -866,7 +866,7 @@ requires-dist = [
 
 [[package]]
 name = "libkoiki"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "components/libkoiki" }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## 概要

v0.8.1 リリース準備として、配布メタデータと実行時に表示するバージョンを `0.8.1` へ更新します。

## 変更内容

- root / `libkoiki` / `koiki_ref_app` のパッケージバージョンを `0.8.1` に更新
- `libkoiki.__version__` を更新
- FastAPI の OpenAPI バージョンを更新
- `/` および `/health` レスポンスの `version` を更新
- `uv.lock` を更新
- 実行時のバージョン表示を確認する回帰テストを追加

## 検証

- `uv lock --check`
- `pytest components/koiki_ref_app/tests/unit/app/test_app_version.py tests/unit/agent_guidance/`
  - 19 passed
- コンテナ実行で `/`、`/health`、OpenAPI の表示が `0.8.1` であることを確認

## リリース手順

本PRを `dev/v0.8` へマージ後、`dev/v0.8 → main` のマージ完了時点で、`main` のマージコミットに注釈付きタグ `v0.8.1` を付与します。